### PR TITLE
Fixed typo in Directive subsection

### DIFF
--- a/doc/speed-manual.tex
+++ b/doc/speed-manual.tex
@@ -370,7 +370,7 @@ To use the \texttt{tcsh} shell, start your script with: \verb|#!/encs/bin/tcsh|
 
 For \texttt{bash}, start with: \verb|#!/encs/bin/bash|
 
-Directives that start with \verb|"$#"|, set the options for the cluster's 
+Directives that start with \verb|"#$"|, set the options for the cluster's 
 ``Altair Grid Engine (AGE)'' scheduler. The script template, \file{template.sh}, 
 provides the essentials:
 


### PR DESCRIPTION
Fixed in source `doc/speed-manual.tex` file and compiled the updated `doc/speed-manual.pdf` output