### PR TITLE
Generate static HTML of the manual to serve on Github Pages

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,11 @@
+# Github Actions
+
+## Deployment to Github Pages
+
+To use Github Actions to deploy the manual's statically generated HTML to Github Pages, we need to first enable it in repository settings.
+
+Steps to enable:
+
+1. At repository homepage on Github, select Settings tab.
+1. On the sidebar, select the Pages subsection.
+1. Under Build and Deployment > Source, select Github Actions from the dropdown menu.

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -1,0 +1,34 @@
+name: Deploy static to Github Pages
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Pages
+        uses: actions/configure-pages@v2
+      - name: Upload web build outputs
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "./doc/web"
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,13 @@
 *.blg
 *.toc
 *.tps
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.tmp
+*.xref
+*.out
+*.dvi
 doc/speed-manual.fdb_latexmk
 doc/speed-manual.fls

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@
 *.xref
 *.out
 *.dvi
+.DS_Store
 doc/speed-manual.fdb_latexmk
 doc/speed-manual.fls

--- a/doc/.devcontainer/.dockerignore
+++ b/doc/.devcontainer/.dockerignore
@@ -1,0 +1,5 @@
+.dockerignore
+devcontainer.json
+docker-compose.yml
+Dockerfile
+README.md

--- a/doc/.devcontainer/Dockerfile
+++ b/doc/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM qmcgaw/latexdevcontainer:latest-full

--- a/doc/.devcontainer/README.md
+++ b/doc/.devcontainer/README.md
@@ -1,0 +1,28 @@
+# Speed HPC Utilities
+
+## Development Container for LaTeX
+
+> For use with [Visual Studio Code](https://code.visualstudio.com/) editor. [Details on this dev container extension](https://code.visualstudio.com/docs/devcontainers/containers).
+
+### Introduction
+
+This folder contains the necessary Docker files and environment dependencies like plugins and extensions to start up a containerized environment with full support for authoring and building LaTeX documents.
+
+The dev container configuration uses the container image from [qmcgaw/latexdevcontainer](https://hub.docker.com/r/qmcgaw/latexdevcontainer/) with `latest-full` tag.
+
+The `devcontainer.json` manifests the recommended Visual Studio Code extensions.
+
+### Requirements
+
+- Windows 10/11 x86-64 >= 1909 | x86-64 Linux distribution | macOS >=10.15 (Catalina)
+- Visual Studio Code
+- [Docker](https://docs.docker.com/get-docker/)
+- (After starting the container), you might need to run `apt install make build-essentail` to install the missing packages in the base container.
+
+### Usage
+
+- Open the repository root folder
+- CTRL + SHIFT + P to bring up the command palette
+- Search for "Dev Container: Reopen in Container" and hit enter to run.
+
+VS Code will then start a Docker container using the image and configurations mentioned above and automatically start a remote connection to the container using `ssh`.

--- a/doc/.devcontainer/devcontainer.json
+++ b/doc/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+{
+	"name": "speed-manual-latex-ws",
+	"dockerComposeFile": ["docker-compose.yml"],
+	"service": "vscode",
+	"runServices": ["vscode"],
+	"shutdownAction": "stopCompose",
+	"workspaceFolder": "/workspace",
+	"postCreateCommand": "",
+	"extensions": [
+		"james-yu.latex-workshop",
+		// Git
+		"eamodio.gitlens",
+		// Other helpers
+		"shardulm94.trailing-spaces",
+		"stkb.rewrap", // rewrap comments after n characters on one line
+		// Other
+		"vscode-icons-team.vscode-icons",
+		"flixs.vs-code-http-server-and-html-preview",
+		"ms-vscode.makefile-tools",
+		"ms-azuretools.vscode-docker"
+	],
+	"settings": {
+		// General settings
+		"files.eol": "\n",
+		// Latex settings
+		"latex-workshop.linting.chktex.enabled": true,
+		"latex-workshop.linting.chktex.exec.path": "",
+		"latex-workshop.latex.clean.subfolder.enabled": true,
+		"latex-workshop.latex.autoClean.run": "onBuilt",
+		"editor.formatOnSave": true,
+		"files.associations": {
+			"*.tex": "latex"
+		},
+		"latex-workshop.latexindent.path": "latexindent",
+		"latex-workshop.latexindent.args": [
+			"-c",
+			"%DIR%/",
+			"%TMPFILE%",
+			"-y=defaultIndent: '%INDENT%'"
+		]
+	}
+}

--- a/doc/.devcontainer/docker-compose.yml
+++ b/doc/.devcontainer/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.2"
+
+services:
+  vscode:
+    build: .
+    image: latexdevcontainer
+    volumes:
+      - ../:/workspace
+      # Docker socket to access Docker server
+      - /var/run/docker.sock:/var/run/docker.sock
+      # SSH directory
+      - ~/.ssh:/root/.ssh
+      # For Windows without WSL, a copy will be made
+      # from /tmp/.ssh to ~/.ssh to fix permissions
+      # - ~/.ssh:/tmp/.ssh:ro
+      # Shell history persistence
+      - ~/.zsh_history:/root/.zsh_history:z
+      # Git config
+      - ~/.gitconfig:/root/.gitconfig
+    environment:
+      - TZ=
+    entrypoint: ["zsh", "-c", "while sleep 1000; do :; done"]
+ 

--- a/doc/.devcontainer/docker-compose.yml
+++ b/doc/.devcontainer/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     image: latexdevcontainer
     volumes:
-      - ../:/workspace
+      - ../../:/workspace
       # Docker socket to access Docker server
       - /var/run/docker.sock:/var/run/docker.sock
       # SSH directory

--- a/doc/.devcontainer/docker-compose.yml
+++ b/doc/.devcontainer/docker-compose.yml
@@ -19,5 +19,9 @@ services:
       - ~/.gitconfig:/root/.gitconfig
     environment:
       - TZ=
+    # This delayed entrypoint shell execution is a workaround 
+    # for a bug introduced in VS Code v1.64 
+    # that prevents initial handshake between the IDE 
+    # to the newly created container
     entrypoint: ["zsh", "-c", "while sleep 1000; do :; done"]
  

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -126,6 +126,13 @@ copy-to-nag: submission
 	cp -f FIG/*.{pdf,png} /groups/n/nag/papers/encs-networking/FIG/
 	chmod -R g+rwX /groups/n/nag/papers/encs-networking 2>/dev/null || cat /dev/null
 
+# Building static HTML requires `make4ht`
+# Works with existing environment
+html:
+		make4ht $(DELIVERABLE) -a debug mathjax -c speed-manual.cfg -d web && \
+		mv ./web/$(DELIVERABLE).html ./web/index.html && \
+		rm $(DELIVERABLE).html $(DELIVERABLE).css
+
 #
 # Clean up
 #
@@ -135,6 +142,6 @@ clean:
           *.lot *.lof *.idx *.bbl *.blg *.ilg *.ind
 
 maintainer-clean: clean
-	rm -f *.pdf
+	rm -f *.pdf *.html *.css
 
 # EOF

--- a/doc/speed-manual.cfg
+++ b/doc/speed-manual.cfg
@@ -1,0 +1,14 @@
+\Preamble{xhtml}
+\Configure{@HEAD}{
+  \HCode{
+    <link rel="stylesheet" href="https://latex.now.sh/style.css"/>
+    \Hnewline
+  }
+  \Css {
+    figure.figure {
+      text-align: left;
+    }
+  }
+}
+\begin{document}
+\EndPreamble

--- a/doc/speed-manual.mk4
+++ b/doc/speed-manual.mk4
@@ -1,0 +1,4 @@
+Make:htlatex()
+Make:bibtex()
+Make:htlatex()
+Make:htlatex()

--- a/doc/speed-manual.tex
+++ b/doc/speed-manual.tex
@@ -791,10 +791,10 @@ home directory:
 \item
 \texttt{ssh-keygen -t ed25519} (default location; blank passphrase) 
 \item
-\texttt{cat id\_ed25519.pub >> authorized\_keys} (if the \file{authorized\_keys}
-file already exists) \emph{OR} \texttt{cat id\_ed25519.pub > authorized\_keys} (if does not) 
+\texttt{cat id\_ed25519.pub >> authorized\_keys} (if the \file{authorized_keys}
+file already exists) \emph{OR} \texttt{cat id\_ed25519.pub > authorized_keys} (if does not) 
 \item
-Set file permissions of \file{authorized\_keys} to 600; of your NFS-mounted home
+Set file permissions of \file{authorized_keys} to 600; of your NFS-mounted home
 to 700 (note that you likely will not have to do anything here, as most people
 will have those permissions by default). 
 \end{itemize}

--- a/doc/speed-manual.tex
+++ b/doc/speed-manual.tex
@@ -816,7 +816,7 @@ important}), and are setting \api{\$TMPDIR} as the in-job location for the
 copies everything from \api{\$TMPDIR} to a directory in the user's NFS-mounted home). 
 Job progress can be monitored by examining the standard-out file (e.g.,
 \file{flu10000.o249}), and/or by examining the ``moment'' file in
-\file{/disk/nobackup/<yourjob>} (hint: it starts with your job-ID) on the node running 
+\verb{/disk/nobackup/<yourjob>} (hint: it starts with your job-ID) on the node running 
 the job. \textbf{Caveat:} take care with journal-file file paths.
 
 % ------------------------------------------------------------------------------

--- a/doc/speed-manual.tex
+++ b/doc/speed-manual.tex
@@ -791,10 +791,10 @@ home directory:
 \item
 \texttt{ssh-keygen -t ed25519} (default location; blank passphrase) 
 \item
-\texttt{cat id\_ed25519.pub >> authorized\_keys} (if the \file{authorized_keys}
-file already exists) \emph{OR} \texttt{cat id\_ed25519.pub > authorized_keys} (if does not) 
+\texttt{cat id\_ed25519.pub >> authorized\_keys} (if the \file{authorized\_keys}
+file already exists) \emph{OR} \texttt{cat id\_ed25519.pub > authorized\_keys} (if does not) 
 \item
-Set file permissions of \file{authorized_keys} to 600; of your NFS-mounted home
+Set file permissions of \file{authorized\_keys} to 600; of your NFS-mounted home
 to 700 (note that you likely will not have to do anything here, as most people
 will have those permissions by default). 
 \end{itemize}
@@ -815,8 +815,8 @@ important}), and are setting \api{\$TMPDIR} as the in-job location for the
 ``moment'' \file{rfile.out} file (in-job, because the last line of the script 
 copies everything from \api{\$TMPDIR} to a directory in the user's NFS-mounted home). 
 Job progress can be monitored by examining the standard-out file (e.g.,
-\file{flu10000.o249}), and/or by examining the ``moment'' file in
-\verb{/disk/nobackup/<yourjob>} (hint: it starts with your job-ID) on the node running 
+\file{flu10000.o249}), and/or by examining the ``moment'' file in 
+\texttt{/disk/nobackup/<yourjob>} (hint: it starts with your job-ID) on the node running
 the job. \textbf{Caveat:} take care with journal-file file paths.
 
 % ------------------------------------------------------------------------------

--- a/doc/web/index.html
+++ b/doc/web/index.html
@@ -1,0 +1,1414 @@
+<!DOCTYPE html> 
+<html lang='en-US' xml:lang='en-US'> 
+<head> <title>Speed: The GCS ENCS Cluster</title> 
+<meta charset='utf-8' /> 
+<meta content='TeX4ht (https://tug.org/tex4ht/)' name='generator' /> 
+<meta content='width=device-width,initial-scale=1' name='viewport' /> 
+<link href='speed-manual.css' rel='stylesheet' type='text/css' /> 
+<meta content='speed-manual.tex' name='src' /> 
+<script>window.MathJax = { tex: { tags: "ams", }, }; </script> 
+ <script async='async' id='MathJax-script' src='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js' type='text/javascript'></script>  
+  <link href='https://latex.now.sh/style.css' rel='stylesheet' />  
+  </head><body>
+   <div class='maketitle'>
+                                                                               
+
+                                                                               
+                                                                               
+
+                                                                               
+
+<h2 class='titleHead'>Speed: The GCS ENCS Cluster</h2>
+<div class='author'> Serguei A. Mokhov <br class='and' />Gillian A. Roper <br class='and' />Network, Security and HPC Group<span class='thank-mark'><a href='#tk-1'><span class='tcrm-1000'>∗</span></a></span>
+<br />         <span class='cmr-9'>Gina Cody School of Engineering and Computer Science</span>
+<br />                       <span class='cmr-9'>Concordia University</span>
+<br />                     <span class='cmr-9'>Montreal, Quebec, Canada</span>
+<br />                 <a class='url' href='rt-ex-hpc~AT~encs.concordia.ca'><span class='cmtt-9'>rt-ex-hpc~AT~encs.concordia.ca</span></a><br /></div><br />
+<div class='date'><span class='cmbx-10'>Version 6.6-dev-04</span></div>
+   <div class='thanks'><br /><a id='tk-1'></a><span class='thank-mark'><span class='tcrm-1000'>∗</span></span>The group acknowledges the initial manual version VI produced by Dr. Scott Bunnell while with
+us.</div></div>
+   <section class='abstract' role='doc-abstract'> 
+<h3 class='abstracttitle'>
+<span class='cmbx-9'>Abstract</span>
+</h3>
+     <!-- l. 68 --><p class='noindent'><span class='cmr-9'>This document primarily presents a quick start guide to the usage of the Gina Cody
+     </span><span class='cmr-9'>School of Engineering and Computer Science compute server farm called “Speed” – the
+     </span><span class='cmr-9'>GCS ENCS Speed cluster, managed by HPC/NAG of GCS ENCS, Concordia University,
+     </span><span class='cmr-9'>Montreal, Canada.</span>
+</p>
+</section>
+   <h3 class='likesectionHead' id='contents'><a id='x1-1000'></a>Contents</h3>
+   <div class='tableofcontents'>
+    <span class='sectionToc'>1 <a href='#introduction' id='QQ2-1-2'>Introduction</a></span>
+<br />     <span class='subsectionToc'>1.1 <a href='#what-speed-comprises' id='QQ2-1-3'>What Speed Comprises</a></span>
+<br />     <span class='subsectionToc'>1.2 <a href='#what-speed-is-ideal-for' id='QQ2-1-4'>What Speed Is Ideal For</a></span>
+<br />     <span class='subsectionToc'>1.3 <a href='#speeds-intent' id='QQ2-1-5'>Speed’s Intent</a></span>
+<br />     <span class='subsectionToc'>1.4 <a href='#available-software' id='QQ2-1-6'>Available Software</a></span>
+<br />     <span class='subsectionToc'>1.5 <a href='#requesting-access' id='QQ2-1-7'>Requesting Access</a></span>
+<br />    <span class='sectionToc'>2 <a href='#job-management' id='QQ2-1-8'>Job Management</a></span>
+<br />     <span class='subsectionToc'>2.1 <a href='#getting-started' id='QQ2-1-9'>Getting Started</a></span>
+<br />      <span class='subsubsectionToc'>2.1.1 <a href='#ssh-connections' id='QQ2-1-10'>SSH Connections</a></span>
+<br />      <span class='subsubsectionToc'>2.1.2 <a href='#environment-set-up' id='QQ2-1-11'>Environment Set Up</a></span>
+<br />     <span class='subsectionToc'>2.2 <a href='#job-submission-basics' id='QQ2-1-12'>Job Submission Basics</a></span>
+<br />      <span class='subsubsectionToc'>2.2.1 <a href='#directives' id='QQ2-1-13'>Directives</a></span>
+<br />      <span class='subsubsectionToc'>2.2.2 <a href='#module-loads' id='QQ2-1-14'>Module Loads</a></span>
+<br />      <span class='subsubsectionToc'>2.2.3 <a href='#user-scripting' id='QQ2-1-15'>User Scripting</a></span>
+<br />     <span class='subsectionToc'>2.3 <a href='#sample-job-script' id='QQ2-1-16'>Sample Job Script</a></span>
+<br />     <span class='subsectionToc'>2.4 <a href='#common-job-management-commands-summary' id='QQ2-1-19'>Common Job Management Commands Summary</a></span>
+<br />     <span class='subsectionToc'>2.5 <a href='#advanced-qsub-options' id='QQ2-1-20'>Advanced <span class='cmtt-10'>qsub </span>Options</a></span>
+<br />     <span class='subsectionToc'>2.6 <a href='#array-jobs' id='QQ2-1-21'>Array Jobs</a></span>
+<br />     <span class='subsectionToc'>2.7 <a href='#requesting-multiple-cores-ie-multithreading-jobs' id='QQ2-1-22'>Requesting Multiple Cores (i.e., Multithreading Jobs)</a></span>
+<br />     <span class='subsectionToc'>2.8 <a href='#interactive-jobs' id='QQ2-1-23'>Interactive Jobs</a></span>
+                                                                               
+
+                                                                               
+<br />     <span class='subsectionToc'>2.9 <a href='#scheduler-environment-variables' id='QQ2-1-24'>Scheduler Environment Variables</a></span>
+<br />     <span class='subsectionToc'>2.10 <a href='#ssh-keys-for-mpi' id='QQ2-1-27'>SSH Keys For MPI</a></span>
+<br />     <span class='subsectionToc'>2.11 <a href='#example-job-script-fluent' id='QQ2-1-28'>Example Job Script: Fluent</a></span>
+<br />     <span class='subsectionToc'>2.12 <a href='#java-jobs' id='QQ2-1-31'>Java Jobs</a></span>
+<br />     <span class='subsectionToc'>2.13 <a href='#scheduling-on-the-gpu-nodes' id='QQ2-1-32'>Scheduling On The GPU Nodes</a></span>
+<br />    <span class='sectionToc'>3 <a href='#creating-virtual-environments' id='QQ2-1-33'>Creating Virtual Environments</a></span>
+<br />     <span class='subsectionToc'>3.1 <a href='#anaconda' id='QQ2-1-34'>Anaconda</a></span>
+<br />      <span class='subsubsectionToc'>3.1.1 <a href='#list-environments' id='QQ2-1-35'>List Environments</a></span>
+<br />      <span class='subsubsectionToc'>3.1.2 <a href='#activate-an-environment' id='QQ2-1-36'>Activate an Environment</a></span>
+<br />     <span class='subsectionToc'>3.2 <a href='#cuda' id='QQ2-1-37'>CUDA</a></span>
+<br />      <span class='subsubsectionToc'>3.2.1 <a href='#special-notes-for-sending-cuda-jobs-to-the-gpu-queue' id='QQ2-1-38'>Special Notes for sending CUDA jobs to the GPU Queue</a></span>
+<br />     <span class='subsectionToc'>3.3 <a href='#efficientdet' id='QQ2-1-39'>efficientdet</a></span>
+<br />    <span class='sectionToc'>4 <a href='#conclusion' id='QQ2-1-40'>Conclusion</a></span>
+<br />     <span class='subsectionToc'>4.1 <a href='#important-limitations' id='QQ2-1-41'>Important Limitations</a></span>
+<br />     <span class='subsectionToc'>4.2 <a href='#tipstricks' id='QQ2-1-42'>Tips/Tricks</a></span>
+<br />     <span class='subsectionToc'>4.3 <a href='#use-cases' id='QQ2-1-43'>Use Cases</a></span>
+<br />    <span class='sectionToc'>A <a href='#history' id='QQ2-1-44'>History</a></span>
+<br />     <span class='subsectionToc'>A.1 <a href='#acknowledgments' id='QQ2-1-45'>Acknowledgments</a></span>
+<br />     <span class='subsectionToc'>A.2 <a href='#phase-' id='QQ2-1-46'>Phase 3</a></span>
+<br />     <span class='subsectionToc'>A.3 <a href='#phase-1' id='QQ2-1-47'>Phase 2</a></span>
+<br />     <span class='subsectionToc'>A.4 <a href='#phase-2' id='QQ2-1-48'>Phase 1</a></span>
+<br />    <span class='sectionToc'>B <a href='#frequently-asked-questions' id='QQ2-1-49'>Frequently Asked Questions</a></span>
+<br />     <span class='subsectionToc'>B.1 <a href='#disk-quota-exceeded-error' id='QQ2-1-50'>“Disk quota exceeded” Error</a></span>
+<br />      <span class='subsubsectionToc'>B.1.1 <a href='#probably-cause' id='QQ2-1-51'>Probably Cause</a></span>
+<br />      <span class='subsubsectionToc'>B.1.2 <a href='#possible-solutions' id='QQ2-1-52'>Possible Solutions</a></span>
+<br />      <span class='subsubsectionToc'>B.1.3 <a href='#example-of-setting-working-directories-for-comsol' id='QQ2-1-53'>Example of setting working directories for <span class='cmtt-10'>COMSOL</span></a></span>
+<br />    <span class='sectionToc'>C <a href='#sister-facilities' id='QQ2-1-54'>Sister Facilities</a></span>
+<br />    <span class='sectionToc'><a href='#annotated-bibliography'>Annotated Bibliography</a></span>
+   </div>
+                                                                               
+
+                                                                               
+   <h3 class='sectionHead' id='introduction'><span class='titlemark'>1   </span> <a id='x1-20001'></a>Introduction</h3>
+<!-- l. 83 --><p class='noindent'>This document contains basic information required to use “Speed” as well as tips and tricks,
+examples, and references to projects and papers that have used Speed. User contributions
+of sample jobs and/ or references are welcome. Details are sent to the <span class='cmtt-10'>hpc-ml </span>mailing
+list.
+</p><!-- l. 89 --><p class='indent'>   <span class='cmbx-10'>Resources:</span>
+</p>
+     <ul class='itemize1'>
+     <li class='itemize'>Our  public  GitHub  page  where  the  manual  and  sample  job  scripts  are  maintained
+     (pull-requests (PRs), subject to review, are welcome):<br class='newline' /><a class='url' href='https://github.com/NAG-DevOps/speed-hpc'><span class='cmtt-10'>https://github.com/NAG-DevOps/speed-hpc</span></a><br class='newline' /><a class='url' href='https://github.com/NAG-DevOps/speed-hpc/pulls'><span class='cmtt-10'>https://github.com/NAG-DevOps/speed-hpc/pulls</span></a>
+     </li>
+     <li class='itemize'>Our official Concordia page for the “Speed” cluster:<br class='newline' /><a class='url' href='https://www.concordia.ca/ginacody/aits/speed.html'><span class='cmtt-10'>https://www.concordia.ca/ginacody/aits/speed.html</span></a><br class='newline' />which includes access request instructions.
+     </li>
+     <li class='itemize'>All registered users are subscribed to the <span class='cmtt-10'>hpc-ml </span>mailing list upon gaining access.
+     </li>
+     <li class='itemize'><a href='https://docs.google.com/presentation/d/1bWbGQvYsuJ4U2WsfLYp8S3yb4i7OdU7QDn3l_Q9mYis'>Introductory slides of Speed presented to departments</a> <span class='cite'>[<a href='#Xspeed-intro-preso'>10</a>]</span>.
+</li></ul>
+<!-- l. 115 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='what-speed-comprises'><span class='titlemark'>1.1   </span> <a id='x1-30001.1'></a>What Speed Comprises</h4>
+     <ul class='itemize1'>
+     <li class='itemize'>Twenty four (24) 32-core compute nodes, each with 512 GB of memory and approximately
+     1 TB of volatile-scratch disk space.
+     </li>
+     <li class='itemize'>Twelve (12) NVIDIA Tesla P6 GPUs, with 16 GB of memory (compatible with the CUDA,
+     OpenGL, OpenCL, and Vulkan APIs).
+                                                                               
+
+                                                                               
+     </li>
+     <li class='itemize'>One AMD FirePro S7150 GPUs, with 8 GB of memory (compatible with the Direct X,
+     OpenGL, OpenCL, and Vulkan APIs).</li></ul>
+<!-- l. 127 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='what-speed-is-ideal-for'><span class='titlemark'>1.2   </span> <a id='x1-40001.2'></a>What Speed Is Ideal For</h4>
+     <ul class='itemize1'>
+     <li class='itemize'>Jobs that are too demanding for a desktop, but that are not worth the hassles associated
+     with the provincial and national clusters.
+     </li>
+     <li class='itemize'>Single-core batch jobs; multithreaded jobs up to 32 cores (i.e., a single machine).
+     </li>
+     <li class='itemize'>Anything that can fit into a 500-GB memory space and a scratch space of approximately
+     1 TB.
+     </li>
+     <li class='itemize'>CPU-based jobs.
+     </li>
+     <li class='itemize'>CUDA GPU jobs (<span class='cmtt-10'>speed-05</span>, <span class='cmtt-10'>speed-17</span>).
+     </li>
+     <li class='itemize'>Non-CUDA GPU jobs using OpenCL (<span class='cmtt-10'>speed-19 </span>and <span class='cmtt-10'>speed-05|17</span>).</li></ul>
+<!-- l. 145 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='speeds-intent'><span class='titlemark'>1.3   </span> <a id='x1-50001.3'></a>Speed’s Intent</h4>
+     <ul class='itemize1'>
+     <li class='itemize'>To Design and Develop, test and run parallel, batch, etc. algorithms, scripts with partial
+     data sets.
+                                                                               
+
+                                                                               
+     </li>
+     <li class='itemize'>
+     <!-- l. 151 --><p class='noindent'>Prepare them for big clusters: </p>
+         <ul class='itemize2'>
+         <li class='itemize'>Calcul Quebec
+         </li>
+         <li class='itemize'>Compute Canada
+         </li>
+         <li class='itemize'>Cloud platforms</li></ul>
+     </li></ul>
+<!-- l. 163 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='available-software'><span class='titlemark'>1.4   </span> <a id='x1-60001.4'></a>Available Software</h4>
+<!-- l. 165 --><p class='noindent'>We have a great number of open-source software available and installed on Speed – various Python,
+CUDA versions, C++/Java compilers, OpenGL, OpenFOAM, OpenCV, TensorFlow, OpenMPI,
+OpenISS, MARF <span class='cite'>[<a href='#Xmarf'>15</a>]</span>, etc. There are also a number of commercial packages, subject to
+licensing contributions, available, such as MATLAB <span class='cite'>[<a href='#Xmatlab'>5</a>, <a href='#Xscholarpedia-matlab'>14</a>]</span>, Abaqus <span class='cite'>[<a href='#Xabaqus'>1</a>]</span>, Ansys, Fluent <span class='cite'>[<a href='#Xfluent'>2</a>]</span>,
+etc.
+</p><!-- l. 173 --><p class='indent'>   To see the packages available, run <span class='cmtt-10'>ls -al /encs/pkg/ </span>on <span class='cmtt-10'>speed.encs</span>.
+</p><!-- l. 176 --><p class='indent'>   In particular, there are over 2200 programs available in <span class='cmtt-10'>/encs/bin </span>and <span class='cmtt-10'>/encs/pkg </span>under Scientific
+Linux 7 (EL7).
+</p>
+     <ul class='itemize1'>
+     <li class='itemize'>
+     <!-- l. 181 --><p class='noindent'>Popular concrete examples: </p>
+         <ul class='itemize2'>
+         <li class='itemize'>MATLAB (R2016b, R2018a, R2018b)
+         </li>
+         <li class='itemize'>Fluent (19.2)
+         </li>
+         <li class='itemize'>Singularity (Docker-like container), can run other OS’s apps, like Ubuntu’s.</li></ul>
+                                                                               
+
+                                                                               
+     </li>
+     <li class='itemize'>We do our best to accommodate custom software requests. Python environments can be used to
+     have user-custom installs in the scratch directory.
+     </li>
+     <li class='itemize'>A number of specific environments are available, too.
+     </li>
+     <li class='itemize'>
+     <!-- l. 197 --><p class='noindent'>Popular examples mentioned (loaded with, <span class='cmtt-10'>module</span>): </p>
+         <ul class='itemize2'>
+         <li class='itemize'>Python (2.3.0 - 3.5.1)
+         </li>
+         <li class='itemize'>Gurobi (7.0.1, 7.5.0, 8.0.0, 8.1.0)
+         </li>
+         <li class='itemize'>Ansys (16, 17, 18, 19)
+         </li>
+         <li class='itemize'>OpenFOAM (2.3.1, 3.0.1, 5.0, 6.0)
+         </li>
+         <li class='itemize'>Cplex 12.6.x to 12.8.x
+         </li>
+         <li class='itemize'>OpenMPI 1.6.x, 1.8.x, 3.1.3</li></ul>
+     </li></ul>
+<!-- l. 214 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='requesting-access'><span class='titlemark'>1.5   </span> <a id='x1-70001.5'></a>Requesting Access</h4>
+<!-- l. 215 --><p class='noindent'>The first step to using the “Speed” cluster is to request access.
+</p><!-- l. 217 --><p class='indent'>   Please email your access request to, <span class='cmtt-10'>rt-ex-hpc AT encs.concordia.ca</span>, including your ENCS
+account’s username.
+</p><!-- l. 220 --><p class='indent'>   If you are a student, please include the name of your Supervisor or instructor as well as a
+statement from that person which indicates that you may have access to “Speed”.
+                                                                               
+
+                                                                               
+</p><!-- l. 225 --><p class='noindent'>
+</p>
+   <h3 class='sectionHead' id='job-management'><span class='titlemark'>2   </span> <a id='x1-80002'></a>Job Management</h3>
+<!-- l. 228 --><p class='noindent'>In these instructions, anything bracketed like so, <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>&lt;&gt;</span></span></span>, indicates a label/value to be replaced (the entire
+bracketed term needs replacement).
+</p><!-- l. 232 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='getting-started'><span class='titlemark'>2.1   </span> <a id='x1-90002.1'></a>Getting Started</h4>
+<!-- l. 234 --><p class='noindent'>Once your ENCS account has been granted access to “Speed”, use your ENCS account credentials to
+create an SSH connection to <span class='cmtt-10'>speed </span>(an alias for <span class='cmtt-10'>speed-submit.encs.concordia.ca</span>).
+</p><!-- l. 239 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='ssh-connections'><span class='titlemark'>2.1.1   </span> <a id='x1-100002.1.1'></a>SSH Connections</h5>
+<!-- l. 241 --><p class='noindent'>If you are connecting from home, and have a Mac or Linux system, in a terminal, this will connect you
+(on a single line):
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-1'>
+ssh -o ProxyCommand="ssh &lt;ENCSusername&gt;@login.encs.concordia.ca nc speed 22"
+  &lt;ENCSusername&gt;@speed.encs.concordia.ca
+</pre>
+<!-- l. 247 --><p class='nopar'>
+</p><!-- l. 249 --><p class='indent'>   Windows users can create SSH connections via PuTTY (or MobaXterm).
+</p><!-- l. 251 --><p class='indent'>   All users are expected to have a basic understanding of Linux and its commonly used
+commands.
+</p><!-- l. 255 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='environment-set-up'><span class='titlemark'>2.1.2   </span> <a id='x1-110002.1.2'></a>Environment Set Up</h5>
+<!-- l. 258 --><p class='noindent'>After creating an SSH connection to “Speed”, you will need to source the “Altair Grid Engine
+(AGE)” scheduler’s settings file. Sourcing the settings file will set the environment variables required
+to execute scheduler commands.
+</p><!-- l. 263 --><p class='indent'>   Based on the UNIX shell type, choose one of the following commands to source the settings
+file.
+</p><!-- l. 266 --><p class='indent'>   csh/<span class='cmtt-10'>tcsh</span>:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-2'>
+source /local/pkg/uge-8.6.3/root/default/common/settings.csh
+</pre>
+<!-- l. 269 --><p class='nopar'>
+</p><!-- l. 271 --><p class='indent'>   Bourne shell/<span class='cmtt-10'>bash</span>:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-3'>
+. /local/pkg/uge-8.6.3/root/default/common/settings.sh
+</pre>
+<!-- l. 274 --><p class='nopar'>
+</p><!-- l. 276 --><p class='indent'>   In order to set up the default ENCS bash shell, executing the following command is also
+required:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-4'>
+printenv ORGANIZATION | grep -qw ENCS || . /encs/Share/bash/profile
+</pre>
+<!-- l. 280 --><p class='nopar'>
+</p><!-- l. 282 --><p class='indent'>   To verify that you have access to the scheduler commands execute <span class='cmtt-10'>qstat -f -u "*"</span>. If an error is
+returned, attempt sourcing the settings file again.
+</p><!-- l. 286 --><p class='indent'>   The next step is to copy a job template to your home directory and to set up your cluster-specific
+storage. Execute the following command from within your home directory. (To move to your home
+directory, type <span class='cmtt-10'>cd </span>at the Linux prompt and press <span class='cmtt-10'>Enter</span>.)
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-5'>
+cp /home/n/nul-uge/template.sh . &amp;&amp; mkdir /speed-scratch/$USER
+</pre>
+<!-- l. 293 --><p class='nopar'>
+</p><!-- l. 295 --><p class='indent'>   <span class='cmbx-10'>Tip: </span>Add the source command to your shell-startup script.
+</p><!-- l. 297 --><p class='indent'>   <span class='cmbx-10'>Tip: </span>the default shell for GCS ENCS users is <span class='cmtt-10'>tcsh</span>. If you would like to use <span class='cmtt-10'>bash</span>, please contact
+<span class='cmtt-10'>rt-ex-hpc AT encs.concordia.ca</span>.
+</p><!-- l. 301 --><p class='indent'>   For <span class='cmbx-10'>new ENCS Users</span>, and/ or those who don’t have a shell-startup script, based on your shell
+type use one of the following commands to copy a start up script from <span class='cmtt-10'>nul-uge</span>’s. home directory to
+your home directory. (To move to your home directory, type <span class='cmtt-10'>cd </span>at the Linux prompt and press
+<span class='cmtt-10'>Enter</span>.)
+</p><!-- l. 306 --><p class='indent'>   csh/<span class='cmtt-10'>tcsh</span>:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-6'>
+cp /home/n/nul-uge/.tcshrc .
+</pre>
+<!-- l. 309 --><p class='nopar'>
+</p><!-- l. 311 --><p class='indent'>   Bourne shell/<span class='cmtt-10'>bash</span>:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-7'>
+cp /home/n/nul-uge/.bashrc .
+</pre>
+<!-- l. 314 --><p class='nopar'>
+</p><!-- l. 316 --><p class='indent'>   Users who already have a shell-startup script, use a text editor, such as <span class='cmtt-10'>vim </span>or <span class='cmtt-10'>emacs</span>, to add the
+source request to your existing shell-startup environment (i.e., to the <a class='url' href='.tcshrc'><span class='cmtt-10'>.tcshrc</span></a> file in your home
+directory).
+</p><!-- l. 320 --><p class='indent'>   csh/<span class='cmtt-10'>tcsh</span>: Sample <a class='url' href='.tcshrc'><span class='cmtt-10'>.tcshrc</span></a> file:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-8'>
+# Speed environment set up
+if ($HOSTNAME  == speed-submit.encs.concordia.ca) then
+   source /local/pkg/uge-8.6.3/root/default/common/settings.csh
+endif
+</pre>
+<!-- l. 327 --><p class='nopar'>
+</p><!-- l. 329 --><p class='indent'>   Bourne shell/<span class='cmtt-10'>bash</span>: Sample <a class='url' href='.bashrc'><span class='cmtt-10'>.bashrc</span></a> file:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-9'>
+# Speed environment set up
+if [ $HOSTNAME = "speed-submit.encs.concordia.ca" ]; then
+    . /local/pkg/uge-8.6.3/root/default/common/settings.sh
+    printenv ORGANIZATION |grep -qw ENCS || .  /encs/Share/bash/profile
+fi
+</pre>
+<!-- l. 337 --><p class='nopar'>
+</p><!-- l. 339 --><p class='indent'>   Note that you will need to either log out and back in, or execute a new shell, for the environment
+changes in the updated <a class='url' href='.tcshrc'><span class='cmtt-10'>.tcshrc</span></a> or <a class='url' href='.bashrc'><span class='cmtt-10'>.bashrc</span></a> file to be applied (<span class='cmbx-10'>important</span>).
+</p><!-- l. 344 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='job-submission-basics'><span class='titlemark'>2.2   </span> <a id='x1-120002.2'></a>Job Submission Basics</h4>
+<!-- l. 346 --><p class='noindent'>Preparing your job for submission is fairly straightforward. Editing a copy of the <a class='url' href='template.sh'><span class='cmtt-10'>template.sh</span></a> you
+moved into your home directory during Section <a href='#environment-set-up'>2.1.2<!-- tex4ht:ref: sect:envsetup  --></a>  is a good place to start. You can also use a job
+script example from our GitHub’s (<a class='url' href='https://github.com/NAG-DevOps/speed-hpc'><span class='cmtt-10'>https://github.com/NAG-DevOps/speed-hpc</span></a>) “src” directory
+and base your job on it.
+</p><!-- l. 352 --><p class='indent'>   Job scripts are broken into four main sections: </p>
+     <ul class='itemize1'>
+     <li class='itemize'>Directives
+     </li>
+     <li class='itemize'>Module Loads
+     </li>
+     <li class='itemize'>User Scripting</li></ul>
+<!-- l. 360 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='directives'><span class='titlemark'>2.2.1   </span> <a id='x1-130002.2.1'></a>Directives</h5>
+<!-- l. 362 --><p class='noindent'>Directives are comments included at the beginning of a job script that set the shell and the options for
+the job scheduler.
+</p><!-- l. 365 --><p class='indent'>   The shebang directive is always the first line of a script. In your job script, this directive sets
+which shell your script’s commands will run in. On “Speed”, we recommend that your script use a
+shell from the <span class='cmtt-10'>/encs/bin </span>directory.
+</p><!-- l. 369 --><p class='indent'>   To use the <span class='cmtt-10'>tcsh </span>shell, start your script with: <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>#!/encs/bin/tcsh</span></span></span>
+</p><!-- l. 371 --><p class='indent'>   For <span class='cmtt-10'>bash</span>, start with: <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>#!/encs/bin/bash</span></span></span>
+</p><!-- l. 373 --><p class='indent'>   Directives that start with <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>"#$"</span></span></span>, set the options for the cluster’s “Altair Grid Engine (AGE)”
+scheduler. The script template, <a class='url' href='template.sh'><span class='cmtt-10'>template.sh</span></a>, provides the essentials:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-10'>
+#$ -N &lt;jobname&gt;
+#$ -cwd
+#$ -m bea
+#$ -pe smp &lt;corecount&gt;
+#$ -l h_vmem=&lt;memory&gt;G
+</pre>
+<!-- l. 383 --><p class='nopar'>
+</p><!-- l. 385 --><p class='indent'>   Replace, <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>&lt;jobname&gt;</span></span></span>, with the name that you want your cluster job to have; <span class='cmtt-10'>-cwd</span>, makes the
+current working directory the “job working directory”, and your standard output file will appear here;
+<span class='cmtt-10'>-m bea</span>, provides e-mail notifications (begin/end/abort); replace, <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>&lt;corecount&gt;</span></span></span>, with the degree of
+(multithreaded) parallelism (i.e., cores) you attach to your job (up to 32), be sure to delete or
+comment out the <span class='obeylines-h'><span class='verb'><span class='cmtt-10'> #$ -pe smp </span></span></span> parameter if it is not relevant; replace, <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>&lt;memory&gt;</span></span></span>, with the value (in
+GB), that you want your job’s memory space to be (up to 500), and all jobs MUST have a
+memory-space assignment.
+</p><!-- l. 395 --><p class='indent'>   If you are unsure about memory footprints, err on assigning a generous memory space to your job
+so that it does not get prematurely terminated (the value given to <span class='cmtt-10'>h_vmem </span>is a hard memory ceiling).
+You can refine <span class='cmtt-10'>h_vmem </span>values for future jobs by monitoring the size of a job’s active memory space on
+<span class='cmtt-10'>speed-submit </span>with:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-11'>
+qstat -j &lt;jobID&gt; | grep maxvmem
+</pre>
+<!-- l. 403 --><p class='nopar'>
+</p><!-- l. 405 --><p class='indent'>   Memory-footprint values are also provided for completed jobs in the final e-mail notification (as,
+“Max vmem”).
+</p><!-- l. 409 --><p class='indent'>   <span class='cmti-10'>Jobs that request a low-memory footprint are more likely to load on a busy cluster.</span>
+</p><!-- l. 412 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='module-loads'><span class='titlemark'>2.2.2   </span> <a id='x1-140002.2.2'></a>Module Loads</h5>
+<!-- l. 414 --><p class='noindent'>As your job will run on a compute or GPU “Speed” node, and not the submit node, any software that
+is needed must be loaded by the job script. Software is loaded within the script just as it would be
+from the command line.
+</p><!-- l. 418 --><p class='indent'>   To see a list of which modules are available, execute the following from the command line on
+<span class='cmtt-10'>speed-submit</span>.
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-12'>
+module avail
+</pre>
+<!-- l. 423 --><p class='nopar'>
+</p><!-- l. 425 --><p class='indent'>   To list for a particular program (<span class='cmtt-10'>matlab</span>, for example):
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-13'>
+module -t avail matlab
+</pre>
+<!-- l. 429 --><p class='nopar'>
+</p><!-- l. 431 --><p class='indent'>   Which, of course, can be shortened to match all that start with a particular letter:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-14'>
+module -t avail m
+</pre>
+<!-- l. 436 --><p class='nopar'>
+</p><!-- l. 438 --><p class='indent'>   Insert the following in your script to load the <span class='cmtt-10'>matlab/R2020a</span>) module:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-15'>
+module load matlab/R2020a/default
+</pre>
+<!-- l. 442 --><p class='nopar'>
+</p><!-- l. 444 --><p class='indent'>   Use, <span class='cmtt-10'>unload</span>, in place of, <span class='cmtt-10'>load</span>, to remove a module from active use.
+</p><!-- l. 446 --><p class='indent'>   To list loaded modules:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-16'>
+module list
+</pre>
+<!-- l. 450 --><p class='nopar'>
+</p><!-- l. 452 --><p class='indent'>   To purge all software in your working environment:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-17'>
+module purge
+</pre>
+<!-- l. 456 --><p class='nopar'>
+</p><!-- l. 458 --><p class='indent'>   Typically, only the <span class='cmtt-10'>module load </span>command will be used in your script.
+</p><!-- l. 461 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='user-scripting'><span class='titlemark'>2.2.3   </span> <a id='x1-150002.2.3'></a>User Scripting</h5>
+<!-- l. 463 --><p class='noindent'>The last part the job script is the scripting that will be executed by the job. This part of
+the job script includes all commands required to set up and execute the task your script
+has been written to do. Any Linux command can be used at this step. This section can
+be a simple call to an executable or a complex loop which iterates through a series of
+commands.
+</p><!-- l. 469 --><p class='indent'>   Every software program has a unique execution framework. It is the responsibility of the script’s
+author (e.g., you) to know what is required for the software used in your script by reviewing the
+software’s documentation. Regardless of which software your script calls, your script should be written
+so that the software knows the location of the input and output files as well as the degree of
+parallelism. Note that the cluster-specific environment variable, <span class='cmtt-10'>NSLOTS</span>, resolves to the value provided
+to the scheduler in the <span class='cmtt-10'>-pe smp </span>option.
+</p><!-- l. 477 --><p class='indent'>   Jobs which touch data-input and data-output files more than once, should make use of <span class='cmtt-10'>TMPDIR</span>, a
+scheduler-provided working space almost 1 TB in size. <span class='cmtt-10'>TMPDIR </span>is created when a job starts, and
+exists on the local disk of the compute node executing your job. Using <span class='cmtt-10'>TMPDIR </span>results
+in faster I/O operations than those to and from shared storage (which is provided over
+NFS).
+</p><!-- l. 483 --><p class='indent'>   An sample job script using <span class='cmtt-10'>TMPDIR </span>is available at <span class='cmtt-10'>/home/n/nul-uge/templateTMPDIR.sh</span>: the job
+is instructed to change to <span class='tctt-1000'>$</span><span class='cmtt-10'>TMPDIR</span>, to make the new directory <span class='cmtt-10'>input</span>, to copy data from
+<span class='tctt-1000'>$</span><span class='cmtt-10'>SGE_O_WORKDIR/references/ </span>to <span class='cmtt-10'>input/ </span>(<span class='tctt-1000'>$</span><span class='cmtt-10'>SGE_O_WORKDIR </span>represents the current working
+directory), to make the new directory <span class='cmtt-10'>results</span>, to execute the program (which takes input from
+<span class='tctt-1000'>$</span><span class='cmtt-10'>TMPDIR/input/ </span>and writes output to <span class='tctt-1000'>$</span><span class='cmtt-10'>TMPDIR/results/</span>), and finally to copy the total end results
+to an existing directory, <span class='cmtt-10'>processed</span>, that is located in the current working directory. TMPDIR only
+exists for the duration of the job, though, so it is very important to copy relevant results from it at
+job’s end.
+</p><!-- l. 494 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='sample-job-script'><span class='titlemark'>2.3   </span> <a id='x1-160002.3'></a>Sample Job Script</h4>
+<!-- l. 496 --><p class='noindent'>Now, let’s look at a basic job script, <a class='url' href='tcsh.sh'><span class='cmtt-10'>tcsh.sh</span></a> in Figure <a href='#-source-code-for-tcshsh'>1<!-- tex4ht:ref: fig:tcsh.sh  --></a>  (you can copy it from our GitHub page or
+from <span class='cmtt-10'>/home/n/nul-uge</span>).
+</p>
+   <figure class='figure' id='-source-code-for-tcshsh'> 
+
+                                                                               
+
+                                                                               
+<a id='x1-160111'></a>
+                                                                               
+
+                                                                               
+<!-- l. 500 --><pre class='lstinputlisting' id='listing-1'><span class='label'><a id='x1-16002r1'></a></span><span style='color:#000000'><span class='cmitt-10'>#</span></span><span style='color:#000000'><span class='cmitt-10'>!/</span></span><span style='color:#000000'><span class='cmitt-10'>encs</span></span><span style='color:#000000'><span class='cmitt-10'>/</span></span><span style='color:#000000'><span class='cmitt-10'>bin</span></span><span style='color:#000000'><span class='cmitt-10'>/</span></span><span style='color:#000000'><span class='cmitt-10'>tcsh</span></span> 
+<span class='label'><a id='x1-16003r2'></a></span> 
+<span class='label'><a id='x1-16004r3'></a></span><span style='color:#000000'><span class='cmitt-10'>#</span></span><span style='color:#000000'><span class='tcit-1000'>$</span></span><span style='color:#000000'> <span class='cmitt-10'>-N </span><span class='cmitt-10'>qsub-test</span> 
+</span><span class='label'><a id='x1-16005r4'></a></span><span style='color:#000000'><span class='cmitt-10'>#</span></span><span style='color:#000000'><span class='tcit-1000'>$</span></span><span style='color:#000000'> <span class='cmitt-10'>-cwd</span> 
+</span><span class='label'><a id='x1-16006r5'></a></span><span style='color:#000000'><span class='cmitt-10'>#</span></span><span style='color:#000000'><span class='tcit-1000'>$</span></span><span style='color:#000000'> <span class='cmitt-10'>-l </span><span class='cmitt-10'>h_vmem=1G</span> 
+</span><span class='label'><a id='x1-16007r6'></a></span> 
+<span class='label'><a id='x1-16008r7'></a></span><span style='color:#000000'><span class='cmtt-10'>sleep</span></span><span style='color:#000000'> <span class='cmtt-10'>30</span> 
+</span><span class='label'><a id='x1-16009r8'></a></span><span style='color:#000000'><span class='cmtt-10'>module</span></span><span style='color:#000000'> <span class='cmtt-10'>load </span><span class='cmtt-10'>gurobi/8.1.0</span> 
+</span><span class='label'><a id='x1-16010r9'></a></span><span style='color:#000000'><span class='cmtt-10'>module</span></span><span style='color:#000000'> <span class='cmtt-10'>list</span></span>
+</pre>
+<figcaption class='caption'><span class='id'>Figure 1: </span><span class='content'>Source code for <a class='url' href='tcsh.sh'><span class='cmtt-10'>tcsh.sh</span></a></span></figcaption><!-- tex4ht:label?: x1-160111  -->
+                                                                               
+
+                                                                               
+   </figure>
+<!-- l. 505 --><p class='indent'>   This script sleeps on a node for 30 seconds, uses the <span class='cmtt-10'>module </span>command to load the <span class='cmtt-10'>gurobi/8.1.0</span>
+environment, and then prints the list of loaded modules into a file. Concentrating on the first four
+lines, the first line is the shell declaration; the next three lines are submission options passed
+to the scheduler. The first, <span class='cmtt-10'>-N</span>, attaches a name to the job (otherwise it is called what
+the job script is called), the second, <span class='cmtt-10'>-cwd</span>, tells the scheduler to execute the job from the
+current working directory, and not to use the default of your home directory (potentially
+important for output-file placement), and the third, <span class='cmtt-10'>-l h_vmem</span>, requests and assigns a 1GB of
+memory space to the job (this is an upper bound, and jobs that attempt to use more will be
+terminated). Note that this third option is <span class='cmti-10'>not </span>optional (if you do not specify a memory space,
+submission of the job will fail). Also notice the syntax that denotes a scheduler option, the,
+<span class='cmtt-10'>#</span><span class='tctt-1000'>$</span>.
+</p><!-- l. 522 --><p class='indent'>   The scheduler command, <span class='cmtt-10'>qsub</span>, is used to submit (non-interactive) jobs. To submit this job: <span class='cmtt-10'>qsub
+</span><span class='cmtt-10'>./tcsh.sh</span>. You will see, <span class='cmtt-10'>"Your job X ("qsub-test") has been submitted"</span>. The command,
+<span class='cmtt-10'>qstat</span>, can be used to look at the status of the cluster: <span class='cmtt-10'>qstat -f -u "*"</span>. You will see something like
+this:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-18'>
+queuename                      qtype resv/used/tot. load_avg arch          states
+---------------------------------------------------------------------------------
+a.q@speed-01.encs.concordia.ca BIP   0/0/32         0.01     lx-amd64
+---------------------------------------------------------------------------------
+a.q@speed-03.encs.concordia.ca BIP   0/0/32         0.01     lx-amd64
+---------------------------------------------------------------------------------
+a.q@speed-25.encs.concordia.ca BIP   0/0/32         0.01     lx-amd64
+---------------------------------------------------------------------------------
+a.q@speed-27.encs.concordia.ca BIP   0/0/32         0.01     lx-amd64
+---------------------------------------------------------------------------------
+g.q@speed-05.encs.concordia.ca BIP   0/0/32         0.02     lx-amd64
+     144   100.00000 qsub-test nul-uge     r     12/03/2018 16:39:30    1
+     62624 0.09843 case_talle x_yzabc      r     11/09/2021 16:50:09    32
+---------------------------------------------------------------------------------
+g.q@speed-17.encs.concordia.ca BIP   0/0/32         0.01     lx-amd64
+---------------------------------------------------------------------------------
+s.q@speed-07.encs.concordia.ca BIP   0/0/32         0.04     lx-amd64
+---------------------------------------------------------------------------------
+s.q@speed-08.encs.concordia.ca BIP   0/0/32         0.01     lx-amd64
+---------------------------------------------------------------------------------
+s.q@speed-09.encs.concordia.ca BIP   0/0/32         0.01     lx-amd64
+---------------------------------------------------------------------------------
+s.q@speed-10.encs.concordia.ca BIP   0/32/32        32.72    lx-amd64
+     62624 0.09843 case_talle x_yzabc      r     11/09/2021 16:50:09    32
+---------------------------------------------------------------------------------
+s.q@speed-11.encs.concordia.ca BIP   0/32/32        32.08    lx-amd64
+     62679 0.14212 CWLR_DF    a_bcdef      r     11/10/2021 17:25:19    32
+---------------------------------------------------------------------------------
+s.q@speed-12.encs.concordia.ca BIP   0/32/32        32.10    lx-amd64
+     62749 0.09000 CLOUDY     z_abc        r     11/11/2021 21:58:12    32
+---------------------------------------------------------------------------------
+s.q@speed-15.encs.concordia.ca BIP   0/4/32         0.03     lx-amd64
+     62753 82.47478 matlabLDPa b_bpxez      r     11/12/2021 08:49:52     4
+---------------------------------------------------------------------------------
+s.q@speed-16.encs.concordia.ca BIP   0/32/32        32.31    lx-amd64
+     62751 0.09000 CLOUDY     z_abc        r     11/12/2021 06:03:54    32
+---------------------------------------------------------------------------------
+s.q@speed-19.encs.concordia.ca BIP   0/32/32        32.22    lx-amd64
+---------------------------------------------------------------------------------
+...
+---------------------------------------------------------------------------------
+s.q@speed-35.encs.concordia.ca BIP   0/32/32        2.78     lx-amd64
+     62754 7.22952 qlogin-tes a_tiyuu      r     11/12/2021 10:31:06    32
+---------------------------------------------------------------------------------
+s.q@speed-36.encs.concordia.ca BIP   0/0/32         0.03     lx-amd64
+etc.
+</pre>
+<!-- l. 576 --><p class='nopar'>
+                                                                               
+
+                                                                               
+</p><!-- l. 579 --><p class='indent'>   Remember that you only have 30 seconds before the job is essentially over, so if you do not see a
+similar output, either adjust the sleep time in the script, or execute the <span class='cmtt-10'>qstat </span>statement more quickly.
+The <span class='cmtt-10'>qstat </span>output listed above shows you that your job is running on node <span class='cmtt-10'>speed-05</span>, that it has a
+job number of 144, that it was started at 16:39:30 on 12/03/2018, and that it is a single-core job (the
+default).
+</p><!-- l. 587 --><p class='indent'>   Once the job finishes, there will be a new file in the directory that the job was started from, with
+the syntax of, <span class='cmtt-10'>"job name".o"job number"</span>, so in this example the file is, qsub <a class='url' href='test.o144'><span class='cmtt-10'>test.o144</span></a>.
+This file represents the standard output (and error, if there is any) of the job in question.
+If you look at the contents of your newly created file, you will see that it contains the
+output of the, <span class='cmtt-10'>module list </span>command. Important information is often written to this
+file.
+</p><!-- l. 595 --><p class='indent'>   Congratulations on your first job!
+</p>
+   <h4 class='subsectionHead' id='common-job-management-commands-summary'><span class='titlemark'>2.4   </span> <a id='x1-170002.4'></a>Common Job Management Commands Summary</h4>
+<!-- l. 601 --><p class='noindent'>Here are useful job-management commands:
+</p>
+     <ul class='itemize1'>
+     <li class='itemize'><span class='cmtt-10'>qsub ./&lt;myscript&gt;.sh</span>: once that your job script is ready, on <span class='cmtt-10'>speed-submit </span>you can
+     submit it using this
+     </li>
+     <li class='itemize'><span class='cmtt-10'>qstat -f -u &lt;ENCSusername&gt;</span>: you can check the status of your job(s)
+     </li>
+     <li class='itemize'><span class='cmtt-10'>qstat -f -u "*"</span>: display cluster status for all users.
+     </li>
+     <li class='itemize'><span class='cmtt-10'>qstat -j [job-ID]</span>:  display  job  information  for  [job-ID]  (said  job  may  be  actually
+     running, or waiting in the queue).
+     </li>
+     <li class='itemize'><span class='cmtt-10'>qdel [job-ID]</span>: delete job [job-ID].
+     </li>
+     <li class='itemize'><span class='cmtt-10'>qhold [job-ID]</span>: hold queued job, [job-ID], from running.
+     </li>
+     <li class='itemize'><span class='cmtt-10'>qrls [job-ID]</span>: release held job [job-ID].
+                                                                               
+
+                                                                               
+     </li>
+     <li class='itemize'><span class='cmtt-10'>qacct -j [job-ID]</span>: get job stats. for completed job [job-ID]. <span class='cmtt-10'>maxvmem </span>is one of the more
+     useful stats.</li></ul>
+<!-- l. 632 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='advanced-qsub-options'><span class='titlemark'>2.5   </span> <a id='x1-180002.5'></a>Advanced <span class='cmtt-10'>qsub </span>Options</h4>
+<!-- l. 635 --><p class='noindent'>In addition to the basic <span class='cmtt-10'>qsub </span>options presented earlier, there are a few additional options that are
+generally useful:
+</p>
+     <ul class='itemize1'>
+     <li class='itemize'><span class='cmtt-10'>-m bea</span>: requests that the scheduler e-mail you when a job (b)egins; (e)nds; (a)borts.
+     Mail is sent to the default address of, <span class='cmtt-10'>"username@encs.concordia.ca"</span>, unless a different
+     address is supplied (see, <span class='cmtt-10'>-M</span>). The report sent when a job ends includes job runtime, as
+     well as the maximum memory value hit (<span class='cmtt-10'>maxvmem</span>).
+     </li>
+     <li class='itemize'><span class='cmtt-10'>-M email@domain.com</span>: requests that the scheduler use this e-mail notification address,
+     rather than the default (see, <span class='cmtt-10'>-m</span>).
+     </li>
+     <li class='itemize'><span class='cmtt-10'>-v variable[=value]</span>: exports an environment variable that can be used by the script.
+     </li>
+     <li class='itemize'><span class='cmtt-10'>-l h_rt=[hour]:[min]:[sec]</span>: sets a job runtime of HH:MM:SS. Note that if you give
+     a single number, that represents <span class='cmti-10'>seconds</span>, not hours.
+     </li>
+     <li class='itemize'><span class='cmtt-10'>-hold_jid [job-ID]</span>: run this job only when job [job-ID] finishes. Held jobs appear in
+     the queue. The many <span class='cmtt-10'>qsub </span>options available are read with, <span class='cmtt-10'>man qsub</span>. Also note that <span class='cmtt-10'>qsub</span>
+     options can be specified during the job-submission command, and these <span class='cmti-10'>override </span>existing
+     script options (if present). The syntax is, <span class='cmtt-10'>qsub [options] /PATHTOSCRIPT</span>, but unlike
+     in the script, the options are specified without the leading <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>#$</span></span></span> (e.g., <span class='cmtt-10'>qsub -N qsub-test
+     </span><span class='cmtt-10'>-cwd -l h_vmem=1G ./tcsh.sh</span>).
+</li></ul>
+                                                                               
+
+                                                                               
+<!-- l. 669 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='array-jobs'><span class='titlemark'>2.6   </span> <a id='x1-190002.6'></a>Array Jobs</h4>
+<!-- l. 671 --><p class='noindent'>Array jobs are those that start a batch job or a parallel job multiple times. Each iteration of the job
+array is called a task and receives a unique job ID.
+</p><!-- l. 674 --><p class='indent'>   To submit an array job, use the <span class='cmtt-10'>t </span>option of the <span class='cmtt-10'>qsub </span>command as follows:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-19'>
+qsub -t n[-m[:s]] &lt;batch_script&gt;
+</pre>
+<!-- l. 679 --><p class='nopar'>
+</p><!-- l. 681 --><p class='indent'>   <span class='cmbx-10'>-t Option Syntax:</span> </p>
+     <ul class='itemize1'>
+     <li class='itemize'><span class='cmtt-10'>n</span>: indicates the start-id.
+     </li>
+     <li class='itemize'><span class='cmtt-10'>m</span>: indicates the max-id.
+     </li>
+     <li class='itemize'><span class='cmtt-10'>s</span>: indicates the step size.</li></ul>
+<!-- l. 691 --><p class='indent'>   <span class='cmbx-10'>Examples:</span> </p>
+     <ul class='itemize1'>
+     <li class='itemize'><span class='cmtt-10'>qsub -t 10 array.sh</span>: submits a job with 1 task where the task-id is 10.
+     </li>
+     <li class='itemize'><span class='cmtt-10'>qsub -t 1-10 array.sh</span>: submits a job with 10 tasks numbered consecutively from 1 to
+     10.
+     </li>
+     <li class='itemize'><span class='cmtt-10'>qsub -t 3-15:3 array.sh</span>: submits a jobs with 5 tasks numbered consecutively with
+     step size 3 (task-ids 3,6,9,12,15).</li></ul>
+<!-- l. 702 --><p class='indent'>   <span class='cmbx-10'>Output files for Array Jobs:</span>
+</p><!-- l. 704 --><p class='indent'>   The default and output and error-files are <span class='cmtt-10'>job_name.[o|e]job_id </span>and<br class='newline' /><span class='cmtt-10'>job_name.[o|e]job_id.task_id</span>. This means that Speed creates an output and an error-file for each
+task generated by the array-job as well as one for the super-ordinate array-job. To alter this behavior
+use the <span class='cmtt-10'>-o </span>and <span class='cmtt-10'>-e </span>option of <span class='cmtt-10'>qsub</span>.
+</p><!-- l. 712 --><p class='indent'>   For more details about Array Job options, please review the manual pages for <span class='cmtt-10'>qsub </span>by executing
+the following at the command line on speed-submit <span class='cmtt-10'>man qsub</span>.
+</p><!-- l. 717 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='requesting-multiple-cores-ie-multithreading-jobs'><span class='titlemark'>2.7   </span> <a id='x1-200002.7'></a>Requesting Multiple Cores (i.e., Multithreading Jobs)</h4>
+<!-- l. 719 --><p class='noindent'>For jobs that can take advantage of multiple machine cores, up to 32 cores (per job) can be requested
+in your script with:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-20'>
+#$ -pe smp [#cores]
+</pre>
+<!-- l. 724 --><p class='nopar'>
+</p><!-- l. 726 --><p class='indent'>   <span class='cmbx-10'>Do not request more cores than you think will be useful</span>, as larger-core jobs
+are more difficult to schedule. On the flip side, though, if you are going to be running
+a program that scales out to the maximum single-machine core count available, please
+(please) request 32 cores, to avoid node oversubscription (i.e., to avoid overloading the
+CPUs).
+</p><!-- l. 732 --><p class='indent'>   Core count associated with a job appears under, “states”, in the, <span class='cmtt-10'>qstat -f -u "*"</span>,
+output.
+</p><!-- l. 736 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='interactive-jobs'><span class='titlemark'>2.8   </span> <a id='x1-210002.8'></a>Interactive Jobs</h4>
+<!-- l. 738 --><p class='noindent'>Job sessions can be interactive, instead of batch (script) based. Such sessions can be useful for testing
+and optimising code and resource requirements prior to batch submission. To request an interactive
+job session, use, <span class='cmtt-10'>qlogin [options]</span>, similarly to a <span class='cmtt-10'>qsub </span>command-line job (e.g., <span class='cmtt-10'>qlogin -N
+</span><span class='cmtt-10'>qlogin-test -l h_vmem=1G</span>). Note that the options that are available for <span class='cmtt-10'>qsub </span>are not necessarily
+available for <span class='cmtt-10'>qlogin</span>, notably, <span class='cmtt-10'>-cwd</span>, and, <span class='cmtt-10'>-v</span>.
+</p><!-- l. 747 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='scheduler-environment-variables'><span class='titlemark'>2.9   </span> <a id='x1-220002.9'></a>Scheduler Environment Variables</h4>
+<!-- l. 749 --><p class='noindent'>The scheduler presents a number of environment variables that can be used in your jobs. Three of the
+more useful are <span class='cmtt-10'>TMPDIR</span>, <span class='cmtt-10'>SGE_O_WORKDIR</span>, and <span class='cmtt-10'>NSLOTS</span>:
+</p>
+     <ul class='itemize1'>
+     <li class='itemize'><span class='tctt-1000'>$</span><span class='cmtt-10'>TMPDIR</span>=the path to the job’s temporary space on the node. It <span class='cmti-10'>only </span>exists for the duration
+     of the job, so if data in the temporary space are important, they absolutely need to be
+     accessed before the job terminates.
+     </li>
+     <li class='itemize'><span class='tctt-1000'>$</span><span class='cmtt-10'>SGE_O_WORKDIR</span>=the path to the job’s working directory (likely an NFS-mounted path).
+     If, <span class='cmtt-10'>-cwd</span>, was stipulated, that path is taken; if not, the path defaults to your home directory.
+     </li>
+     <li class='itemize'><span class='tctt-1000'>$</span><span class='cmtt-10'>NSLOTS</span>=the number of cores requested for the job. This variable can be used in place of
+     hardcoded thread-request declarations.
+</li></ul>
+<!-- l. 770 --><p class='noindent'>In Figure <a href='#-source-code-for-tmpdirsh'>2<!-- tex4ht:ref: fig:tmpdir.sh  --></a>  is a sample script, using all three.
+</p>
+   <figure class='figure' id='-source-code-for-tmpdirsh'> 
+
+                                                                               
+
+                                                                               
+<a id='x1-220152'></a>
+                                                                               
+
+                                                                               
+<!-- l. 774 --><pre class='lstinputlisting' id='listing-2'><span class='label'><a id='x1-22002r1'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>!/</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>encs</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>/</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>bin</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>/</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>tcsh</span></span> 
+<span class='label'><a id='x1-22003r2'></a></span> 
+<span class='label'><a id='x1-22004r3'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='tcit-0800'>$</span></span><span style='color:#000000'> <span class='cmitt-10x-x-80'>-N </span><span class='cmitt-10x-x-80'>envs</span> 
+</span><span class='label'><a id='x1-22005r4'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='tcit-0800'>$</span></span><span style='color:#000000'> <span class='cmitt-10x-x-80'>-cwd</span> 
+</span><span class='label'><a id='x1-22006r5'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='tcit-0800'>$</span></span><span style='color:#000000'> <span class='cmitt-10x-x-80'>-pe </span><span class='cmitt-10x-x-80'>smp </span><span class='cmitt-10x-x-80'>8</span> 
+</span><span class='label'><a id='x1-22007r6'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='tcit-0800'>$</span></span><span style='color:#000000'> <span class='cmitt-10x-x-80'>-l </span><span class='cmitt-10x-x-80'>h_vmem=32G</span> 
+</span><span class='label'><a id='x1-22008r7'></a></span> 
+<span class='label'><a id='x1-22009r8'></a></span><span style='color:#000000'><span class='cmtt-8'>cd</span></span><span style='color:#000000'> <span class='tctt-0800'>$</span><span class='cmtt-8'>TMPDIR</span> 
+</span><span class='label'><a id='x1-22010r9'></a></span><span style='color:#000000'><span class='cmtt-8'>mkdir</span></span><span style='color:#000000'> <span class='cmtt-8'>input</span> 
+</span><span class='label'><a id='x1-22011r10'></a></span><span style='color:#000000'><span class='cmtt-8'>rsync</span></span><span style='color:#000000'> <span class='cmtt-8'>-av </span><span class='tctt-0800'>$</span><span class='cmtt-8'>SGE_O_WORKDIR/references/ </span><span class='cmtt-8'>input/</span> 
+</span><span class='label'><a id='x1-22012r11'></a></span><span style='color:#000000'><span class='cmtt-8'>mkdir</span></span><span style='color:#000000'> <span class='cmtt-8'>results</span> 
+</span><span class='label'><a id='x1-22013r12'></a></span><span style='color:#000000'><span class='cmtt-8'>STAR</span></span><span style='color:#000000'> <span class='cmtt-8'>--inFiles </span><span class='tctt-0800'>$</span><span class='cmtt-8'>TMPDIR/input </span><span class='cmtt-8'>--parallel </span><span class='tctt-0800'>$</span><span class='cmtt-8'>NSLOTS </span><span class='cmtt-8'>--outFiles </span><span class='tctt-0800'>$</span><span class='cmtt-8'>TMPDIR/results</span> 
+</span><span class='label'><a id='x1-22014r13'></a></span><span style='color:#000000'><span class='cmtt-8'>rsync</span></span><span style='color:#000000'> <span class='cmtt-8'>-av </span><span class='tctt-0800'>$</span><span class='cmtt-8'>TMPDIR/results/ </span><span class='tctt-0800'>$</span><span class='cmtt-8'>SGE_O_WORKDIR/processed/</span></span>
+</pre>
+<figcaption class='caption'><span class='id'>Figure 2: </span><span class='content'>Source code for <a class='url' href='tmpdir.sh'><span class='cmtt-10'>tmpdir.sh</span></a></span></figcaption><!-- tex4ht:label?: x1-220152  -->
+                                                                               
+
+                                                                               
+   </figure>
+   <h4 class='subsectionHead' id='ssh-keys-for-mpi'><span class='titlemark'>2.10   </span> <a id='x1-230002.10'></a>SSH Keys For MPI</h4>
+<!-- l. 783 --><p class='noindent'>Some programs effect their parallel processing via MPI (which is a communication protocol). An
+example of such software is Fluent. MPI needs to have ‘passwordless login’ set up, which means SSH
+keys. In your NFS-mounted home directory:
+</p>
+     <ul class='itemize1'>
+     <li class='itemize'><span class='cmtt-10'>cd .ssh</span>
+     </li>
+     <li class='itemize'><span class='cmtt-10'>ssh-keygen -t ed25519 </span>(default location; blank passphrase)
+     </li>
+     <li class='itemize'><span class='cmtt-10'>cat id_ed25519.pub &gt;&gt; authorized_keys </span>(if the <a class='url' href='authorized_keys'><span class='cmtt-10'>authorized_keys</span></a> file already exists)
+     <span class='cmti-10'>OR </span><span class='cmtt-10'>cat id_ed25519.pub &gt; authorized_keys </span>(if does not)
+     </li>
+     <li class='itemize'>Set  file  permissions  of  <a class='url' href='authorized_keys'><span class='cmtt-10'>authorized_keys</span></a> to  600;  of  your  NFS-mounted  home  to  700
+     (note that you likely will not have to do anything here, as most people will have those
+     permissions by default).</li></ul>
+<!-- l. 803 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='example-job-script-fluent'><span class='titlemark'>2.11   </span> <a id='x1-240002.11'></a>Example Job Script: Fluent</h4>
+   <figure class='figure' id='-source-code-for-fluentsh'> 
+
+                                                                               
+
+                                                                               
+<a id='x1-240163'></a>
+                                                                               
+
+                                                                               
+<!-- l. 806 --><pre class='lstinputlisting' id='listing-3'><span class='label'><a id='x1-24002r1'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>!/</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>encs</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>/</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>bin</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>/</span></span><span style='color:#000000'><span class='cmitt-10x-x-80'>tcsh</span></span> 
+<span class='label'><a id='x1-24003r2'></a></span> 
+<span class='label'><a id='x1-24004r3'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='tcit-0800'>$</span></span><span style='color:#000000'> <span class='cmitt-10x-x-80'>-N </span><span class='cmitt-10x-x-80'>flu10000</span> 
+</span><span class='label'><a id='x1-24005r4'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='tcit-0800'>$</span></span><span style='color:#000000'> <span class='cmitt-10x-x-80'>-cwd</span> 
+</span><span class='label'><a id='x1-24006r5'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='tcit-0800'>$</span></span><span style='color:#000000'> <span class='cmitt-10x-x-80'>-m </span><span class='cmitt-10x-x-80'>bea</span> 
+</span><span class='label'><a id='x1-24007r6'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='tcit-0800'>$</span></span><span style='color:#000000'> <span class='cmitt-10x-x-80'>-pe </span><span class='cmitt-10x-x-80'>smp </span><span class='cmitt-10x-x-80'>8</span> 
+</span><span class='label'><a id='x1-24008r7'></a></span><span style='color:#000000'><span class='cmitt-10x-x-80'>#</span></span><span style='color:#000000'><span class='tcit-0800'>$</span></span><span style='color:#000000'> <span class='cmitt-10x-x-80'>-l </span><span class='cmitt-10x-x-80'>h_vmem=160G</span> 
+</span><span class='label'><a id='x1-24009r8'></a></span> 
+<span class='label'><a id='x1-24010r9'></a></span><span style='color:#000000'><span class='cmtt-8'>module</span></span><span style='color:#000000'> <span class='cmtt-8'>load </span><span class='cmtt-8'>ansys/19.0/default</span> 
+</span><span class='label'><a id='x1-24011r10'></a></span><span style='color:#000000'><span class='cmtt-8'>cd</span></span><span style='color:#000000'> <span class='tctt-0800'>$</span><span class='cmtt-8'>TMPDIR</span> 
+</span><span class='label'><a id='x1-24012r11'></a></span> 
+<span class='label'><a id='x1-24013r12'></a></span><span style='color:#000000'><span class='cmtt-8'>fluent</span></span><span style='color:#000000'> <span class='cmtt-8'>3ddp </span><span class='cmtt-8'>-g </span><span class='cmtt-8'>-i </span><span class='tctt-0800'>$</span><span class='cmtt-8'>SGE_O_WORKDIR/fluentdata/info.jou </span><span class='cmtt-8'>-sgepe </span><span class='cmtt-8'>smp </span><span class='cmtt-8'>&gt; </span><span class='cmtt-8'>call.txt</span> 
+</span><span class='label'><a id='x1-24014r13'></a></span> 
+<span class='label'><a id='x1-24015r14'></a></span><span style='color:#000000'><span class='cmtt-8'>rsync</span></span><span style='color:#000000'> <span class='cmtt-8'>-av </span><span class='tctt-0800'>$</span><span class='cmtt-8'>TMPDIR/ </span><span class='tctt-0800'>$</span><span class='cmtt-8'>SGE_O_WORKDIR/fluentparallel/</span></span>
+</pre>
+<figcaption class='caption'><span class='id'>Figure 3: </span><span class='content'>Source code for <a class='url' href='fluent.sh'><span class='cmtt-10'>fluent.sh</span></a></span></figcaption><!-- tex4ht:label?: x1-240163  -->
+                                                                               
+
+                                                                               
+   </figure>
+<!-- l. 811 --><p class='indent'>   The job script in Figure <a href='#-source-code-for-fluentsh'>3<!-- tex4ht:ref: fig:fluent.sh  --></a>  runs Fluent in parallel over 32 cores. Of note, we have requested e-mail
+notifications (<span class='cmtt-10'>-m</span>), are defining the parallel environment for, <span class='cmtt-10'>fluent</span>, with, <span class='cmtt-10'>-sgepe smp </span>(<span class='cmbx-10'>very
+</span><span class='cmbx-10'>important</span>), and are setting <span class='tctt-1000'>$</span><span class='cmtt-10'>TMPDIR </span>as the in-job location for the ”moment” <a class='url' href='rfile.out'><span class='cmtt-10'>rfile.out</span></a> file (in-job,
+because the last line of the script copies everything from <span class='tctt-1000'>$</span><span class='cmtt-10'>TMPDIR </span>to a directory in the user’s
+NFS-mounted home). Job progress can be monitored by examining the standard-out file (e.g.,
+<a class='url' href='flu10000.o249'><span class='cmtt-10'>flu10000.o249</span></a>), and/or by examining the ”moment” file in <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>/disk/nobackup/&lt;yourjob&gt;</span></span></span> (hint: it
+starts with your job-ID) on the node running the job. <span class='cmbx-10'>Caveat: </span>take care with journal-file file
+paths.
+</p>
+   <h4 class='subsectionHead' id='java-jobs'><span class='titlemark'>2.12   </span> <a id='x1-250002.12'></a>Java Jobs</h4>
+<!-- l. 825 --><p class='noindent'>Jobs that call <span class='cmtt-10'>java </span>have a memory overhead, which needs to be taken into account when assigning a
+value to <span class='cmtt-10'>h_vmem</span>. Even the most basic <span class='cmtt-10'>java </span>call, <span class='cmtt-10'>java -Xmx1G -version</span>, will need to have, <span class='cmtt-10'>-l
+</span><span class='cmtt-10'>h_vmem=5G</span>, with the 4-GB difference representing the memory overhead. Note that this memory
+overhead grows proportionally with the value of <span class='cmtt-10'>-Xmx</span>. To give you an idea, when <span class='cmtt-10'>-Xmx </span>has a
+value of 100G, <span class='cmtt-10'>h_vmem </span>has to be at least 106G; for 200G, at least 211G; for 300G, at least
+314G.
+</p><!-- l. 836 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='scheduling-on-the-gpu-nodes'><span class='titlemark'>2.13   </span> <a id='x1-260002.13'></a>Scheduling On The GPU Nodes</h4>
+<!-- l. 838 --><p class='noindent'>The primary cluster has two GPU nodes, each with six Tesla (CUDA-compatible) P6 cards: each card
+has 2048 cores and 16GB of RAM. Though note that the P6 is mainly a single-precision card, so
+unless you need the GPU double precision, double-precision calculations will be faster on a CPU
+node.
+</p><!-- l. 843 --><p class='indent'>   Job scripts for the GPU queue differ in that they do not need these statements:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-21'>
+#$ -pe smp &lt;threadcount&gt;
+#$ -l h_vmem=&lt;memory&gt;G
+</pre>
+<!-- l. 849 --><p class='nopar'>
+</p><!-- l. 851 --><p class='indent'>   But do need this statement, which attaches either a single GPU, or, two GPUs, to the
+job:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-22'>
+#$ -l gpu=[1|2]
+</pre>
+<!-- l. 856 --><p class='nopar'>
+</p><!-- l. 858 --><p class='indent'>   Single-GPU jobs are granted 5 CPU cores and 80GB of system memory, and dual-GPU jobs are
+granted 10 CPU cores and 160GB of system memory. A total of <span class='cmti-10'>four </span>GPUs can be actively attached
+to any one user at any given time.
+</p><!-- l. 863 --><p class='indent'>   Once that your job script is ready, you can submit it to the GPU queue with:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-23'>
+qsub -q g.q ./&lt;myscript&gt;.sh
+</pre>
+<!-- l. 868 --><p class='nopar'>
+</p><!-- l. 870 --><p class='indent'>   And you can query <span class='cmtt-10'>nvidia-smi </span>on the node that is running your job with:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-24'>
+ssh &lt;username&gt;@speed[-05|-17] nvidia-smi
+</pre>
+<!-- l. 874 --><p class='nopar'>
+</p><!-- l. 876 --><p class='indent'>   Status of the GPU queue can be queried with:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-25'>
+qstat -f -u "*" -q g.q
+</pre>
+<!-- l. 880 --><p class='nopar'>
+</p><!-- l. 882 --><p class='indent'>   <span class='cmbx-10'>Very important note </span>regarding TensorFlow and PyTorch: if you are planning to run TensorFlow
+and/or PyTorch multi-GPU jobs, do not use the <span class='cmtt-10'>tf.distribute </span>and/or<br class='newline' /><span class='cmtt-10'>torch.nn.DataParallel </span>functions, as they will crash the compute node (100% certainty). This
+appears to be the current hardware’s architecture’s defect. The workaround is to either manually
+effect GPU parallelisation (TensorFlow has an example on how to do this), or to run on a single
+GPU.
+</p><!-- l. 895 --><p class='noindent'><span class='cmbx-10'>Important</span>
+</p><!-- l. 899 --><p class='indent'>   Users without permission to use the GPU nodes can submit jobs to the <span class='cmtt-10'>g.q </span>queue but those jobs
+will hang and never run.
+</p><!-- l. 902 --><p class='indent'>   There are two GPUs in both <span class='cmtt-10'>speed-05 </span>and <span class='cmtt-10'>speed-17</span>, and one in <span class='cmtt-10'>speed-19</span>. Their availability is
+seen with, <span class='cmtt-10'>qstat -F g </span>(note the capital):
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-26'>
+queuename                      qtype resv/used/tot. load_avg arch          states
+---------------------------------------------------------------------------------
+...
+---------------------------------------------------------------------------------
+g.q@speed-05.encs.concordia.ca BIP   0/0/32         0.04     lx-amd64
+        hc:gpu=6
+---------------------------------------------------------------------------------
+g.q@speed-17.encs.concordia.ca BIP   0/0/32         0.01     lx-amd64
+        hc:gpu=6
+---------------------------------------------------------------------------------
+...
+---------------------------------------------------------------------------------
+s.q@speed-19.encs.concordia.ca BIP   0/32/32        32.37    lx-amd64
+        hc:gpu=1
+---------------------------------------------------------------------------------
+etc.
+</pre>
+<!-- l. 924 --><p class='nopar'>
+</p><!-- l. 927 --><p class='indent'>   This status demonstrates that all five are available (i.e., have not been requested as resources). To
+specifically request a GPU node, add, <span class='cmtt-10'>-l g=[#GPUs]</span>, to your <span class='cmtt-10'>qsub </span>(statement/script) or <span class='cmtt-10'>qlogin</span>
+(statement) request. For example, <span class='cmtt-10'>qsub -l h_vmem=1G -l g=1 ./count.sh</span>. You will see that this
+job has been assigned to one of the GPU nodes:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-27'>
+queuename                      qtype resv/used/tot. load_avg arch          states
+---------------------------------------------------------------------------------
+g.q@speed-05.encs.concordia.ca BIP 0/0/32 0.01 lx-amd64  hc:gpu=6
+---------------------------------------------------------------------------------
+g.q@speed-17.encs.concordia.ca BIP 0/0/32 0.01 lx-amd64  hc:gpu=6
+---------------------------------------------------------------------------------
+s.q@speed-19.encs.concordia.ca BIP 0/1/32 0.04 lx-amd64  hc:gpu=0 (haff=1.000000)
+       538 100.00000 count.sh   sbunnell     r     03/07/2019 02:39:39     1
+---------------------------------------------------------------------------------
+etc.
+</pre>
+<!-- l. 946 --><p class='nopar'>
+</p><!-- l. 949 --><p class='indent'>   And that there are no more GPUs available on that node (<span class='cmtt-10'>hc:gpu=0</span>). Note that no more than two
+GPUs can be requested for any one job.
+</p><!-- l. 953 --><p class='noindent'>
+</p>
+   <h3 class='sectionHead' id='creating-virtual-environments'><span class='titlemark'>3   </span> <a id='x1-270003'></a>Creating Virtual Environments</h3>
+<!-- l. 956 --><p class='noindent'>The following documentation is specific to the <span class='cmbx-10'>Speed </span>HPC Facility at the Gina Cody School of
+Engineering and Computer Science.
+</p><!-- l. 960 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='anaconda'><span class='titlemark'>3.1   </span> <a id='x1-280003.1'></a>Anaconda</h4>
+<!-- l. 962 --><p class='noindent'>To create an anaconda environment in your speed-scratch directory, use the <span class='cmtt-10'>prefix </span>option when
+executing <span class='cmtt-10'>conda create</span>. For example, to create an anaconda environment for <span class='cmtt-10'>ai_user</span>, execute the
+following at the command line:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-28'>
+conda create --prefix /speed-scratch/a_user/myconda
+</pre>
+<!-- l. 968 --><p class='nopar'>
+</p><!-- l. 971 --><p class='noindent'><span class='cmbx-10'>Note: </span>Without the <span class='cmtt-10'>prefix </span>option, the <span class='cmtt-10'>conda create </span>command creates the environment in
+texttta_user’s home directory by default.
+</p><!-- l. 977 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='list-environments'><span class='titlemark'>3.1.1   </span> <a id='x1-290003.1.1'></a>List Environments</h5>
+<!-- l. 979 --><p class='noindent'>To view your conda environments, type: <span class='cmtt-10'>conda info --envs</span>
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-29'>
+# conda environments:
+#
+base                  *  /encs/pkg/anaconda3-2019.07/root
+                         /speed-scratch/a_user/myconda
+</pre>
+<!-- l. 986 --><p class='nopar'>
+</p><!-- l. 989 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='activate-an-environment'><span class='titlemark'>3.1.2   </span> <a id='x1-300003.1.2'></a>Activate an Environment</h5>
+<!-- l. 991 --><p class='noindent'>Activate the environment <span class='cmtt-10'>speedscratcha_usermyconda </span>as follows
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-30'>
+conda activate /speed-scratch/a_user/myconda
+</pre>
+<!-- l. 994 --><p class='nopar'> After activating your environment, add <span class='cmtt-10'>pip </span>to your environment by using
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-31'>
+conda install pip
+</pre>
+<!-- l. 998 --><p class='nopar'> This will install <span class='cmtt-10'>pip </span>and <span class='cmtt-10'>pip</span>’s dependencies, including python, into the environment.
+</p><!-- l. 1003 --><p class='noindent'><span class='cmbx-10'>Important Note: </span><span class='cmtt-10'>pip </span>(and <span class='cmtt-10'>pip3</span>) are used to install modules from the python distribution while
+<span class='cmtt-10'>conda install </span>installs modules from anaconda’s repository.
+</p><!-- l. 1010 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='cuda'><span class='titlemark'>3.2   </span> <a id='x1-310003.2'></a>CUDA</h4>
+<!-- l. 1012 --><p class='noindent'>When calling <span class='cmtt-10'>CUDA </span>within job scripts, it is important to create a link to the desired <span class='cmtt-10'>CUDA </span>libraries and
+set the runtime link path to the same libraries. For example, to use the <span class='cmtt-10'>cuda-11.5 </span>libraries, specify
+the following in your Makefile.
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-32'>
+-L/encs/pkg/cuda-11.5/root/lib64 -Wl,-rpath,/encs/pkg/cuda-11.5/root/lib64
+</pre>
+<!-- l. 1019 --><p class='nopar'>
+</p><!-- l. 1021 --><p class='indent'>   In your job script, specify the version of <span class='cmtt-10'>gcc </span>to use prior to calling cuda. For example: <span class='cmtt-10'>module
+</span><span class='cmtt-10'>load gcc/8.4 </span>or <span class='cmtt-10'>module load gcc/9.3</span>
+</p><!-- l. 1028 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='special-notes-for-sending-cuda-jobs-to-the-gpu-queue'><span class='titlemark'>3.2.1   </span> <a id='x1-320003.2.1'></a>Special Notes for sending CUDA jobs to the GPU Queue</h5>
+<!-- l. 1030 --><p class='noindent'>It is not possible to create a <span class='cmtt-10'>qlogin </span>session on to a node in the <span class='cmbx-10'>GPU Queue </span>(<span class='cmtt-10'>g.q</span>). As direct logins
+to these nodes is not available, jobs must be submitted to the <span class='cmbx-10'>GPU Queue </span>in order to compile and
+link.
+</p><!-- l. 1035 --><p class='indent'>   We have several versions of CUDA installed in:
+                                                                               
+
+                                                                               
+</p>
+   <pre class='verbatim' id='verbatim-33'>
+/encs/pkg/cuda-11.5/root/
+/encs/pkg/cuda-10.2/root/
+/encs/pkg/cuda-9.2/root
+</pre>
+<!-- l. 1040 --><p class='nopar'>
+</p><!-- l. 1042 --><p class='indent'>   For CUDA to compile properly for the GPU queue, edit your Makefile replacing <span class='cmtt-10'>usrlocalcuda</span>
+with one of the above.
+</p><!-- l. 1046 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='efficientdet'><span class='titlemark'>3.3   </span> <a id='x1-330003.3'></a>efficientdet</h4>
+<!-- l. 1048 --><p class='noindent'>The following steps describing how to create an efficientdet environment on <span class='cmti-10'>Speed</span>, were submitted by
+a member of Dr. Amer’s research group.
+</p>
+     <ul class='itemize1'>
+     <li class='itemize'>Enter        your        ENCS        user        account’s        speed-scratch        directory
+     <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>cd /speed-scratch/&lt;encs_username&gt;</span></span></span>
+     </li>
+     <li class='itemize'>load                                python                                <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>module load python/3.8.3</span></span></span>
+     create virtual environment <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>python3 -m venv &lt;env_name&gt;</span></span></span> activate virtual environment
+     <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>source &lt;env_name&gt;/bin/activate.csh</span></span></span> install DL packages for Efficientdet</li></ul>
+                                                                               
+
+                                                                               
+<pre class='verbatim' id='verbatim-34'>
+pip install tensorflow==2.7.0
+pip install lxml&gt;=4.6.1
+pip install absl-py&gt;=0.10.0
+pip install matplotlib&gt;=3.0.3
+pip install numpy&gt;=1.19.4
+pip install Pillow&gt;=6.0.0
+pip install PyYAML&gt;=5.1
+pip install six&gt;=1.15.0
+pip install tensorflow-addons&gt;=0.12
+pip install tensorflow-hub&gt;=0.11
+pip install neural-structured-learning&gt;=1.3.1
+pip install tensorflow-model-optimization&gt;=0.5
+pip install Cython&gt;=0.29.13
+pip install git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
+</pre>
+<!-- l. 1076 --><p class='nopar'>
+</p><!-- l. 1079 --><p class='noindent'>
+</p>
+   <h3 class='sectionHead' id='conclusion'><span class='titlemark'>4   </span> <a id='x1-340004'></a>Conclusion</h3>
+<!-- l. 1082 --><p class='noindent'>The cluster is, “first come, first served”, until it fills, and then job position in the queue is
+based upon past usage. The scheduler does attempt to fill gaps, though, so sometimes a
+single-core job of lower priority will schedule before a multi-core job of higher priority, for
+example.
+</p><!-- l. 1088 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='important-limitations'><span class='titlemark'>4.1   </span> <a id='x1-350004.1'></a>Important Limitations</h4>
+     <ul class='itemize1'>
+     <li class='itemize'>New users are restricted to a total of 32 cores: write to <a class='url' href='rt-ex-hpc@encs.concordia.ca'><span class='cmtt-10'>rt-ex-hpc@encs.concordia.ca</span></a>
+     if you need more temporarily (256 is the maximum possible, or, 8 jobs of 32 cores each).
+     </li>
+     <li class='itemize'>Job sessions are a maximum of one week in length (only 24 hours, though, for interactive
+     jobs).
+     </li>
+     <li class='itemize'>
+                                                                               
+
+                                                                               
+     <!-- l. 1101 --><p class='noindent'>Scripts can live in your NFS-provided home, but any substantial data need to be in your
+     cluster-specific directory (located at <span class='obeylines-h'><span class='verb'><span class='cmtt-10'>/speed-scratch/&lt;ENCSusername&gt;/</span></span></span>).
+     </p><!-- l. 1105 --><p class='noindent'>NFS is great for acute activity, but is not ideal for chronic activity. Any data that a
+     job will read more than once should be copied at the start to the scratch disk of a
+     compute node using <span class='tctt-1000'>$</span><span class='cmtt-10'>TMPDIR </span>(and, perhaps, <span class='tctt-1000'>$</span><span class='cmtt-10'>SGE_O_WORKDIR</span>), any intermediary job data
+     should be produced in <span class='tctt-1000'>$</span><span class='cmtt-10'>TMPDIR</span>, and once a job is near to finishing, those data should
+     be copied to your NFS-mounted home (or other NFS-mounted space) from <span class='tctt-1000'>$</span><span class='cmtt-10'>TMPDIR </span>(to,
+     perhaps, <span class='tctt-1000'>$</span><span class='cmtt-10'>SGE_O_WORKDIR</span>). In other words, IO-intensive operations should be effected
+     locally whenever possible, saving network activity for the start and end of jobs.
+     </p></li>
+     <li class='itemize'>Your current resource allocation is based upon past usage, which is an amalgamation of
+     approximately one week’s worth of past wallclock (i.e., time spent on the node(s)) and
+     CPU activity (on the node(s)).
+     </li>
+     <li class='itemize'>Jobs should NEVER be run outside of the province of the scheduler. Repeat offenders
+     risk loss of cluster access.
+</li></ul>
+<!-- l. 1128 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='tipstricks'><span class='titlemark'>4.2   </span> <a id='x1-360004.2'></a>Tips/Tricks</h4>
+     <ul class='itemize1'>
+     <li class='itemize'>Files/scripts must have Linux line breaks in them (not Windows ones).
+     </li>
+     <li class='itemize'>Use <span class='cmtt-10'>rsync</span>, not <span class='cmtt-10'>scp</span>, when moving data around.
+     </li>
+     <li class='itemize'>If you are going to move many many files between NFS-mounted storage and the cluster,
+     <span class='cmtt-10'>tar </span>everything up first.
+     </li>
+     <li class='itemize'>If you intend to use a different shell (e.g., <span class='cmtt-10'>bash</span> <span class='cite'>[<a href='#Xaosa-book-vol1-bash'>13</a>]</span>), you will need to source a different
+     scheduler file, and will need to change the shell declaration in your script(s).
+                                                                               
+
+                                                                               
+     </li>
+     <li class='itemize'>The load displayed in <span class='cmtt-10'>qstat </span>by default is <span class='cmtt-10'>np_load</span>, which is load/#cores. That means
+     that a load of, “1”, which represents a fully active core, is displayed as \(0.03\) on the node in
+     question, as there are 32 cores on a node. To display load “as is” (such that a node with
+     a fully active core displays a load of approximately \(1.00\)), add the following to your <a class='url' href='.tcshrc'><span class='cmtt-10'>.tcshrc</span></a>
+     file: <span class='cmtt-10'>setenv SGE_LOAD_AVG load_avg</span>
+     </li>
+     <li class='itemize'>Try to request resources that closely match what your job will use: requesting many more
+     cores or much more memory than will be needed makes a job more difficult to schedule
+     when resources are scarce.
+     </li>
+     <li class='itemize'>E-mail, <span class='cmtt-10'>rt-ex-hpc AT encs.concordia.ca</span>, with any concerns/questions.</li></ul>
+<!-- l. 1161 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='use-cases'><span class='titlemark'>4.3   </span> <a id='x1-370004.3'></a>Use Cases</h4>
+     <ul class='itemize1'>
+     <li class='itemize'>
+     <!-- l. 1166 --><p class='noindent'>HPC Committee’s initial batch about 6 students (end of 2019): </p>
+         <ul class='itemize2'>
+         <li class='itemize'>10000 iterations job in Fluent finished in \(&lt;26\) hours vs. 46 hours in Calcul Quebec</li></ul>
+     </li>
+     <li class='itemize'>
+     <!-- l. 1172 --><p class='noindent'>NAG’s MAC spoofer analyzer <span class='cite'>[<a href='#Xmac-spoofer-analyzer-intro-c3s2e2014'>9</a>, <a href='#Xmac-spoofer-analyzer-detail-fps2014'>8</a>]</span>, such as <a class='url' href='https://github.com/smokhov/atsm/tree/master/examples/flucid'><span class='cmtt-10'>https://github.com/smokhov/atsm/tree/master/examples/flucid</span></a>
+     </p>
+         <ul class='itemize2'>
+         <li class='itemize'>compilation of forensic computing reasoning cases about false or true positives of
+         hardware address spoofing in the labs</li></ul>
+     </li>
+     <li class='itemize'>
+     <!-- l. 1179 --><p class='noindent'>S4 LAB/GIPSY R&amp;D Group’s: </p>
+                                                                               
+
+                                                                               
+         <ul class='itemize2'>
+         <li class='itemize'>MARFCAT and MARFPCAT (OSS signal processing and machine learning tools for
+         vulnerable and weak code analysis and network packet capture analysis) <span class='cite'>[<a href='#Xmarfcat-nlp-ai2014'>11</a>, <a href='#Xmarfcat-sate2010-nist'>6</a>, <a href='#Xfingerprinting-mal-traffic'>3</a>]</span>
+         </li>
+         <li class='itemize'>Web service data conversion and analysis
+         </li>
+         <li class='itemize'>Forensic Lucid encoders (translation of large log data into Forensic Lucid <span class='cite'>[<a href='#Xmokhov-phd-thesis-2013'>7</a>]</span> for
+         forensic analysis)
+         </li>
+         <li class='itemize'>Genomic alignment exercises</li></ul>
+     </li>
+     <li class='itemize'>Parna Niksirat, Adriana Daca, and Krzysztof Skonieczny. The effects of reduced-gravity on
+     planetary rover mobility. <span class='cmti-10'>International Journal of Robotics Research</span>, 39(7):797–811,
+     2020</li></ul>
+<!-- l. 1200 --><p class='noindent'>
+</p>
+   <h3 class='sectionHead' id='history'><span class='titlemark'>A   </span> <a id='x1-38000A'></a>History</h3>
+<!-- l. 1203 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='acknowledgments'><span class='titlemark'>A.1   </span> <a id='x1-39000A.1'></a>Acknowledgments</h4>
+<!-- l. 1206 --><p class='noindent'>The first 6 versions of this manual and early job script samples, Singularity testing and user support
+were produced/done by Dr. Scott Bunnell during his time at Concordia as a part of the NAG/HPC
+group. We thank him for his contributions.
+</p><!-- l. 1212 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='phase-'><span class='titlemark'>A.2   </span> <a id='x1-40000A.2'></a>Phase 3</h4>
+<!-- l. 1214 --><p class='noindent'>Phase 3 had 4 vidpro nodes added from Dr. Amer totalling 6x P6 and 6x V100 GPUs
+added.
+                                                                               
+
+                                                                               
+</p><!-- l. 1218 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='phase-1'><span class='titlemark'>A.3   </span> <a id='x1-41000A.3'></a>Phase 2</h4>
+<!-- l. 1220 --><p class='noindent'>Phase 2 saw 6x NVIDIA Tesla P6 added and 8x more compute nodes. The P6s replaced 4x of FirePro
+S7150.
+</p><!-- l. 1224 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='phase-2'><span class='titlemark'>A.4   </span> <a id='x1-42000A.4'></a>Phase 1</h4>
+<!-- l. 1226 --><p class='noindent'>Phase 1 of Speed was of the following configuration:
+</p>
+     <ul class='itemize1'>
+     <li class='itemize'>Sixteen,  32-core  nodes,  each  with  512 GB  of  memory  and  approximately  1 TB  of
+     volatile-scratch disk space.
+     </li>
+     <li class='itemize'>Five AMD FirePro S7150 GPUs, with 8 GB of memory (compatible with the Direct X,
+     OpenGL, OpenCL, and Vulkan APIs).</li></ul>
+<!-- l. 1236 --><p class='noindent'>
+</p>
+   <h3 class='sectionHead' id='frequently-asked-questions'><span class='titlemark'>B   </span> <a id='x1-43000B'></a>Frequently Asked Questions</h3>
+<!-- l. 1240 --><p class='noindent'>
+</p>
+   <h4 class='subsectionHead' id='disk-quota-exceeded-error'><span class='titlemark'>B.1   </span> <a id='x1-44000B.1'></a>“Disk quota exceeded” Error</h4>
+<!-- l. 1243 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='probably-cause'><span class='titlemark'>B.1.1   </span> <a id='x1-45000B.1.1'></a>Probably Cause</h5>
+<!-- l. 1245 --><p class='noindent'>The <span class='cmtt-10'>‘‘Disk quota exceeded’’ </span>Error occurs when your application has run out of disk space to write
+to. On Speed this error can be returned when:
+     </p><ol class='enumerate1'>
+<li class='enumerate' id='x1-45002x1'>The <span class='cmtt-10'>/tmp </span>directory on the speed node your application is running on is full and cannot
+     be written to.
+                                                                               
+
+                                                                               
+     </li>
+<li class='enumerate' id='x1-45004x2'>Your NFS-provided home is full and cannot be written to.</li></ol>
+<!-- l. 1254 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='possible-solutions'><span class='titlemark'>B.1.2   </span> <a id='x1-46000B.1.2'></a>Possible Solutions</h5>
+<!-- l. 1256 --><p class='noindent'>
+     </p><ol class='enumerate1'>
+<li class='enumerate' id='x1-46002x1'>Use the <span class='cmbx-10'>-cwd </span>job script option to make the directory that the job script is submitted
+     from the <span class='cmtt-10'>job working directory</span>, e.g., the directory to store all output files in.
+     </li>
+<li class='enumerate' id='x1-46004x2'>
+     <!-- l. 1262 --><p class='noindent'>As previously mentioned in this manual, it is recommended to use local disk space
+     for IO intensive operations, however, as the <span class='cmtt-10'>/tmp </span>on the speed machines is <span class='cmtt-10'>1GB </span>in
+     size it may be necessary for scripts to store temporary data elsewhere. Review the
+     documentation for the module(s) you are calling within your script to determine how to
+     set working directories for that application. The basic steps for this solution are:
+     </p>
+         <ul class='itemize1'>
+         <li class='itemize'>Review the documentation for the module(s) you are calling within your script to
+         determine how to set working directories for that application.
+         </li>
+         <li class='itemize'>Create a directory in speed-scratch for your temporary files. For example, to create a
+         subdirector called <span class='cmtt-10'>tmp </span>for user <span class='cmbx-10'>a_user</span>, in that user’s speed-scratch directory execute:
+         <span class='cmbx-10'>mkdir m 750 speedscratcha_usertmp</span>
+         </li>
+         <li class='itemize'>If  necessary,  create  a  subdirectory  for  recovery  files  as  well:  <span class='cmbx-10'>mkdir  m  750
+         </span><span class='cmbx-10'>speedscratcha_userrecovery</span>
+         </li>
+         <li class='itemize'>Use  the  documentation  to  update  your  script(s)  and  command  calls  to  use  the
+         working directories created in the previous steps.</li></ul>
+     </li></ol>
+                                                                               
+
+                                                                               
+<!-- l. 1288 --><p class='noindent'>
+</p>
+   <h5 class='subsubsectionHead' id='example-of-setting-working-directories-for-comsol'><span class='titlemark'>B.1.3   </span> <a id='x1-47000B.1.3'></a>Example of setting working directories for <span class='cmtt-10'>COMSOL</span></h5>
+     <ul class='itemize1'>
+     <li class='itemize'>
+     <!-- l. 1292 --><p class='noindent'>Create directories for recovery, temporary, and configuration files. For example, to create these
+     directories for <span class='cmbx-10'>a_user</span>:
+                                                                               
+
+                                                                               
+</p>
+     <pre class='verbatim' id='verbatim-35'>
+     mkdir -m 750 -p /speed-scratch/a_user/comsol/{recovery,tmp,config}
+</pre>
+     <!-- l. 1296 --><p class='nopar'>
+     </p></li>
+     <li class='itemize'>
+     <!-- l. 1298 --><p class='noindent'>Add the following command switches to the COMSOL command to use the directories created
+     for <span class='cmbx-10'>a_user </span>above:
+                                                                               
+
+                                                                               
+</p>
+     <pre class='verbatim' id='verbatim-36'>
+     -recoverydir /speed-scratch/a_user/comsol/recovery
+     -tmpdir /speed-scratch/a_user/comsol/tmp
+     -configuration/speed-scratch/a_user/comsol/config
+</pre>
+     <!-- l. 1304 --><p class='nopar'></p></li></ul>
+<!-- l. 1308 --><p class='noindent'>
+</p>
+   <h3 class='sectionHead' id='sister-facilities'><span class='titlemark'>C   </span> <a id='x1-48000C'></a>Sister Facilities</h3>
+<!-- l. 1310 --><p class='noindent'>Below is a list of resources and facilities similar to Speed at various capacities. Depending on your
+research group and needs, they might be available to you. They are not managed by HPC/NAG of
+AITS, so contact their respective representatives.
+</p>
+     <ul class='itemize1'>
+     <li class='itemize'><span class='cmtt-10'>computation.encs </span>CPU only 3-machine cluster running longer jobs without a scheduler
+     </li>
+     <li class='itemize'><span class='cmtt-10'>apini.encs </span>cluster for teaching and MPI programming (see the corresponding course)
+     </li>
+     <li class='itemize'>Computer Science and Software Engineering (CSSE) Virya GPU Cluster (2 nodes totalling
+     16 V100 NVIDIA GPUs), contact Alexander Aric at <span class='cmtt-10'>gpu-help AT encs </span>to request access
+     if you are a CSSE member
+     </li>
+     <li class='itemize'>Dr. Maria Amer’s VidPro group’s nodes in Speed with additional V100 and P6 GPUs
+     (use <span class='cmtt-10'>a.q </span>for those nodes).
+     </li>
+     <li class='itemize'>Dr. Hassan Rivaz’s <span class='cmtt-10'>impactlab.encs </span>Lambda Labs station
+     </li>
+     <li class='itemize'>Dr. Ivan Contreras’ servers
+                                                                               
+
+                                                                               
+     </li>
+     <li class='itemize'>Compute Canada / Calcul Quebec</li></ul>
+                                                                               
+
+                                                                               
+<p id='annotated-bibliography'><a id='Q1-1-55'></a>
+   </p><h3 class='likesectionHead' id='references'><a id='x1-49000'></a><span class='cmr-9'>References</span></h3>
+<!-- l. 1 --><p class='noindent'>
+    </p><div class='thebibliography'>
+    <p class='bibitem'><span class='biblabel'>
+  <span class='cmr-9'>[1]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xabaqus'></a><span class='cmr-9'>3DS.                                  Abaqus.                                  [online],            2019–2021.</span>
+    <a class='url' href='https://www.3ds.com/products-services/simulia/products/abaqus/'><span class='cmtt-9'>https://www.3ds.com/products-services/simulia/products/abaqus/</span></a><span class='cmr-9'>.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+  <span class='cmr-9'>[2]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xfluent'></a><span class='cmr-9'>ANSYS.                               FLUENT.                               [online],           2000–2012.</span>
+    <a class='url' href='http://www.ansys.com/Products/Simulation+Technology/Fluid+Dynamics/ANSYS+FLUENT'><span class='cmtt-9'>http://www.ansys.com/Products/Simulation+Technology/Fluid+Dynamics/ANSYS+FLUENT</span></a><span class='cmr-9'>.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+  <span class='cmr-9'>[3]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xfingerprinting-mal-traffic'></a><span class='cmr-9'>Amine  Boukhtouta,  Nour-Eddine  Lakhdari,  Serguei A.  Mokhov,  and  Mourad  Debbabi.
+    </span><span class='cmr-9'>Towards fingerprinting malicious traffic.  In </span><span class='cmti-9'>Proceedings of ANT’13</span><span class='cmr-9'>, volume 19, pages 548–555.
+    </span><span class='cmr-9'>Elsevier, June 2013.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+  <span class='cmr-9'>[4]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xaosa-book-vol1'></a><span class='cmr-9'>Amy  Brown  and  Greg  Wilson,  editors.    </span><span class='cmti-9'>The  Architecture  of  Open  Source  Applications:
+    </span><span class='cmti-9'>Elegance, Evolution, and a Few Fearless Hacks</span><span class='cmr-9'>, volume I.  aosabook.org, March 2012.  Online at</span>
+    <a class='url' href='http://aosabook.org'><span class='cmtt-9'>http://aosabook.org</span></a><span class='cmr-9'>.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+  <span class='cmr-9'>[5]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xmatlab'></a><span class='cmr-9'>MathWorks. MATLAB. [online], 2000–2012. </span><a class='url' href='http://www.mathworks.com/products/matlab/'><span class='cmtt-9'>http://www.mathworks.com/products/matlab/</span></a><span class='cmr-9'>.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+  <span class='cmr-9'>[6]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xmarfcat-sate2010-nist'></a><span class='cmr-9'>Serguei A.  Mokhov.     The  use  of  machine  learning  with  signal-  and  NLP  processing
+    </span><span class='cmr-9'>of  source  code  to  fingerprint,  detect,  and  classify  vulnerabilities  and  weaknesses  with
+    </span><span class='cmr-9'>MARFCAT.       Technical   Report   NIST   SP   500-283,   NIST,   October   2011.       Report:</span>
+    <a class='url' href='http://www.nist.gov/manuscript-publication-search.cfm?pub_id=909407'><span class='cmtt-9'>http://www.nist.gov/manuscript-publication-search.cfm?pub_id=909407</span></a><span class='cmr-9'>, online e-print at</span>
+    <a class='url' href='http://arxiv.org/abs/1010.2511'><span class='cmtt-9'>http://arxiv.org/abs/1010.2511</span></a><span class='cmr-9'>.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+  <span class='cmr-9'>[7]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xmokhov-phd-thesis-2013'></a><span class='cmr-9'>Serguei A. Mokhov. </span><span class='cmti-9'>Intensional Cyberforensics</span><span class='cmr-9'>. PhD thesis, Department of Computer Science
+    </span><span class='cmr-9'>and Software Engineering, Concordia University, Montreal, Canada, September 2013.  Online at</span>
+    <a class='url' href='http://arxiv.org/abs/1312.0466'><span class='cmtt-9'>http://arxiv.org/abs/1312.0466</span></a><span class='cmr-9'>.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+  <span class='cmr-9'>[8]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xmac-spoofer-analyzer-detail-fps2014'></a><span class='cmr-9'>Serguei A. Mokhov, Michael J. Assels, Joey Paquet, and Mourad Debbabi. Automating MAC
+    </span><span class='cmr-9'>spoofer evidence gathering and encoding for investigations.  In Frederic Cuppens et al., editors,
+    </span><span class='cmti-9'>Proceedings of The 7th International Symposium on Foundations &amp; Practice of Security (FPS’14)</span><span class='cmr-9'>,
+    </span><span class='cmr-9'>LNCS 8930, pages 168–183. Springer, November 2014. Full paper.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+  <span class='cmr-9'>[9]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xmac-spoofer-analyzer-intro-c3s2e2014'></a><span class='cmr-9'>Serguei A. Mokhov, Michael J. Assels, Joey Paquet, and Mourad Debbabi. Toward automated
+    </span><span class='cmr-9'>MAC spoofer investigations.  In </span><span class='cmti-9'>Proceedings of C3S2E’14</span><span class='cmr-9'>, pages 179–184. ACM, August 2014.
+    </span><span class='cmr-9'>Short paper.</span>
+                                                                               
+
+                                                                               
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+ <span class='cmr-9'>[10]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xspeed-intro-preso'></a><span class='cmr-9'>Serguei A.      Mokhov      and      Scott      Bunnell.                 Speed      server      farm:
+    </span><span class='cmr-9'>Gina      Cody      School      of      ENCS      HPC      facility.               [online],      2018–2019.</span>
+    <a class='url' href='https://docs.google.com/presentation/d/1bWbGQvYsuJ4U2WsfLYp8S3yb4i7OdU7QDn3l_Q9mYis'><span class='cmtt-9'>https://docs.google.com/presentation/d/1bWbGQvYsuJ4U2WsfLYp8S3yb4i7OdU7QDn3l_Q9mYis</span></a><span class='cmr-9'>.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+ <span class='cmr-9'>[11]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xmarfcat-nlp-ai2014'></a><span class='cmr-9'>Serguei A. Mokhov, Joey Paquet, and Mourad Debbabi. The use of NLP techniques in static
+    </span><span class='cmr-9'>code analysis to detect weaknesses and vulnerabilities.  In Maria Sokolova and Peter van Beek,
+    </span><span class='cmr-9'>editors, </span><span class='cmti-9'>Proceedings of Canadian Conference on AI’14</span><span class='cmr-9'>, volume 8436 of </span><span class='cmti-9'>LNAI</span><span class='cmr-9'>, pages 326–332.
+    </span><span class='cmr-9'>Springer, May 2014. Short paper.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+ <span class='cmr-9'>[12]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xniksirat2020'></a><span class='cmr-9'>Parna Niksirat, Adriana Daca, and Krzysztof Skonieczny.  The effects of reduced-gravity on
+    </span><span class='cmr-9'>planetary rover mobility. </span><span class='cmti-9'>International Journal of Robotics Research</span><span class='cmr-9'>, 39(7):797–811, 2020.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+ <span class='cmr-9'>[13]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xaosa-book-vol1-bash'></a><span class='cmr-9'>Chet    Ramey.          The    Bourne-Again    Shell.          In    Brown    and    Wilson    </span><span class='cite'><span class='cmr-9'>[</span><a href='#Xaosa-book-vol1'><span class='cmr-9'>4</span></a><span class='cmr-9'>]</span></span><span class='cmr-9'>.</span>
+    <a class='url' href='http://aosabook.org/en/bash.html'><span class='cmtt-9'>http://aosabook.org/en/bash.html</span></a><span class='cmr-9'>.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+ <span class='cmr-9'>[14]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xscholarpedia-matlab'></a><span class='cmr-9'>Rob      Schreiber.                 MATLAB.                 </span><span class='cmti-9'>Scholarpedia</span><span class='cmr-9'>,      2(6):2929,      2007.</span>
+    <a class='url' href='http://www.scholarpedia.org/article/MATLAB'><span class='cmtt-9'>http://www.scholarpedia.org/article/MATLAB</span></a><span class='cmr-9'>.</span>
+    </p>
+    <p class='bibitem'><span class='biblabel'>
+ <span class='cmr-9'>[15]</span><span class='bibsp'><span class='cmr-9'>   </span></span></span><a id='Xmarf'></a><span class='cmr-9'>The   MARF   Research   and   Development   Group.      The   Modular   Audio   Recognition
+    </span><span class='cmr-9'>Framework   and   its   Applications.        [online],   2002–2014.        </span><a class='url' href='http://marf.sf.net'><span class='cmtt-9'>http://marf.sf.net</span></a>  <span class='cmr-9'>and</span>
+    <a class='url' href='http://arxiv.org/abs/0905.1235'><span class='cmtt-9'>http://arxiv.org/abs/0905.1235</span></a><span class='cmr-9'>, last viewed May 2015.</span>
+</p>
+    </div>
+                                                                               
+
+                                                                               
+    
+</body> 
+</html>

--- a/doc/web/speed-manual.css
+++ b/doc/web/speed-manual.css
@@ -1,0 +1,179 @@
+ 
+/* start css.sty */
+.cmbx-12x-x-144{font-size:172%; font-weight: bold;}
+.cmbx-12x-x-144{ font-weight: bold;}
+.cmbx-12x-x-144{ font-weight: bold;}
+.cmr-9{font-size:90%;}
+.cmtt-9{font-size:90%;font-family: monospace,monospace;}
+.cmtt-9{font-family: monospace,monospace;}
+.cmtt-9{font-family: monospace,monospace;}
+.cmtt-9{font-family: monospace,monospace;}
+.cmtt-9{font-family: monospace,monospace;}
+.cmbx-10{ font-weight: bold;}
+.cmbx-10{ font-weight: bold;}
+.cmbx-10{ font-weight: bold;}
+.cmbx-9{font-size:90%; font-weight: bold;}
+.cmbx-9{ font-weight: bold;}
+.cmbx-9{ font-weight: bold;}
+.cmtt-10{font-family: monospace,monospace;}
+.cmtt-10{font-family: monospace,monospace;}
+.cmtt-10{font-family: monospace,monospace;}
+.cmtt-10{font-family: monospace,monospace;}
+.cmtt-10{font-family: monospace,monospace;}
+.cmti-10{ font-style: italic;}
+.tctt-1000{font-family: monospace,monospace;}
+.tctt-1000{font-family: monospace,monospace;}
+.cmitt-10{font-family: monospace,monospace; font-style: italic;}
+.cmitt-10{font-family: monospace,monospace; font-style: italic;}
+.cmtt-8{font-size:80%;font-family: monospace,monospace;}
+.cmtt-8{font-family: monospace,monospace;}
+.cmtt-8{font-family: monospace,monospace;}
+.cmtt-8{font-family: monospace,monospace;}
+.cmtt-8{font-family: monospace,monospace;}
+.cmitt-10x-x-80{font-size:80%;font-family: monospace,monospace; font-style: italic;}
+.cmitt-10x-x-80{font-family: monospace,monospace; font-style: italic;}
+.tcit-0800{font-size:80%;}
+.tctt-0800{font-size:80%;font-family: monospace,monospace;}
+.tctt-0800{font-family: monospace,monospace;}
+.cmti-9{font-size:90%; font-style: italic;}
+p{margin-top:0;margin-bottom:0}
+p.indent{text-indent:0;}
+p + p{margin-top:1em;}
+p + div, p + pre {margin-top:1em;}
+div + p, pre + p {margin-top:1em;}
+a { overflow-wrap: break-word; word-wrap: break-word; word-break: break-word; hyphens: auto; }
+@media print {div.crosslinks {visibility:hidden;}}
+table.tabular{border-collapse: collapse; border-spacing: 0;}
+a img { border-top: 0; border-left: 0; border-right: 0; }
+center { margin-top:1em; margin-bottom:1em; }
+td center { margin-top:0em; margin-bottom:0em; }
+.Canvas { position:relative; }
+img.math{vertical-align:middle;}
+div.par-math-display, div.math-display{text-align:center;}
+li p.indent { text-indent: 0em }
+li p:first-child{ margin-top:0em; }
+li p:last-child, li div:last-child { margin-bottom:0.5em; }
+li p:first-child{ margin-bottom:0; }
+li p~ul:last-child, li p~ol:last-child{ margin-bottom:0.5em; }
+.enumerate1 {list-style-type:decimal;}
+.enumerate2 {list-style-type:lower-alpha;}
+.enumerate3 {list-style-type:lower-roman;}
+.enumerate4 {list-style-type:upper-alpha;}
+div.newtheorem { margin-bottom: 2em; margin-top: 2em;}
+div.newtheorem .head{font-weight: bold;}
+.obeylines-h,.obeylines-v {white-space: nowrap; }
+div.obeylines-v p { margin-top:0; margin-bottom:0; }
+.overline{ text-decoration:overline; }
+.overline img{ border-top: 1px solid black; }
+td.displaylines {text-align:center; white-space:nowrap;}
+.centerline {text-align:center;}
+.rightline {text-align:right;}
+pre.verbatim {font-family: monospace,monospace; text-align:left; clear:both; }
+.fbox {padding-left:3.0pt; padding-right:3.0pt; text-indent:0pt; border:solid black 0.4pt; }
+div.fbox {display:table}
+div.center div.fbox {text-align:center; clear:both; padding-left:3.0pt; padding-right:3.0pt; text-indent:0pt; border:solid black 0.4pt; }
+div.minipage{width:100%;}
+div.center, div.center div.center {text-align: center; margin-left:1em; margin-right:1em;}
+div.center div {text-align: left;}
+div.flushright, div.flushright div.flushright {text-align: right;}
+div.flushright div {text-align: left;}
+div.flushleft {text-align: left;}
+.underline{ text-decoration:underline; }
+.underline img{ border-bottom: 1px solid black; margin-bottom:1pt; }
+.framebox-c, .framebox-l, .framebox-r { padding-left:3.0pt; padding-right:3.0pt; text-indent:0pt; border:solid black 0.4pt; }
+.framebox-c {text-align:center;}
+.framebox-l {text-align:left;}
+.framebox-r {text-align:right;}
+span.thank-mark{ vertical-align: super }
+span.footnote-mark sup.textsuperscript, span.footnote-mark a sup.textsuperscript{ font-size:80%; }
+div.tabular, div.center div.tabular {text-align: center; margin-top:0.5em; margin-bottom:0.5em; }
+table.tabular td p{margin-top:0em;}
+table.tabular {margin-left: auto; margin-right: auto;}
+td p:first-child{ margin-top:0em; }
+td p:last-child{ margin-bottom:0em; }
+div.td00{ margin-left:0pt; margin-right:0pt; }
+div.td01{ margin-left:0pt; margin-right:5pt; }
+div.td10{ margin-left:5pt; margin-right:0pt; }
+div.td11{ margin-left:5pt; margin-right:5pt; }
+table[rules] {border-left:solid black 0.4pt; border-right:solid black 0.4pt; }
+td.td00{ padding-left:0pt; padding-right:0pt; }
+td.td01{ padding-left:0pt; padding-right:5pt; }
+td.td10{ padding-left:5pt; padding-right:0pt; }
+td.td11{ padding-left:5pt; padding-right:5pt; }
+table[rules] {border-left:solid black 0.4pt; border-right:solid black 0.4pt; }
+.hline hr, .cline hr{ height : 0px; margin:0px; }
+.hline td, .cline td{ padding: 0; }
+.hline hr, .cline hr{border:none;border-top:1px solid black;}
+.hline {border-top: 1px solid black;}
+.tabbing-right {text-align:right;}
+div.float, div.figure {margin-left: auto; margin-right: auto;}
+div.float img {text-align:center;}
+div.figure img {text-align:center;}
+.marginpar,.reversemarginpar {width:20%; float:right; text-align:left; margin-left:auto; margin-top:0.5em; font-size:85%; text-decoration:underline;}
+.marginpar p,.reversemarginpar p{margin-top:0.4em; margin-bottom:0.4em;}
+.reversemarginpar{float:left;}
+table.equation {width:100%;}
+.equation td{text-align:center; }
+td.equation { margin-top:1em; margin-bottom:1em; } 
+td.equation-label { width:5%; text-align:center; }
+td.eqnarray4 { width:5%; white-space: normal; }
+td.eqnarray2 { width:5%; }
+table.eqnarray-star, table.eqnarray {width:100%;}
+div.eqnarray{text-align:center;}
+div.array {text-align:center;}
+div.pmatrix {text-align:center;}
+table.pmatrix {width:100%;}
+span.pmatrix img{vertical-align:middle;}
+div.pmatrix {text-align:center;}
+table.pmatrix {width:100%;}
+span.bar-css {text-decoration:overline;}
+img.cdots{vertical-align:middle;}
+.partToc a, .partToc, .likepartToc a, .likepartToc {line-height: 200%; font-weight:bold; font-size:110%;}
+.chapterToc a, .chapterToc, .likechapterToc a, .likechapterToc, .appendixToc a, .appendixToc {line-height: 200%; font-weight:bold;}
+.index-item, .index-subitem, .index-subsubitem {display:block}
+div.caption {text-indent:-2em; margin-left:3em; margin-right:1em; text-align:left;}
+div.caption span.id{font-weight: bold; white-space: nowrap; }
+h1.partHead{text-align: center}
+p.bibitem { text-indent: -2em; margin-left: 2em; margin-top:0.6em; margin-bottom:0.6em; }
+p.bibitem-p { text-indent: 0em; margin-left: 2em; margin-top:0.6em; margin-bottom:0.6em; }
+.paragraphHead, .likeparagraphHead { margin-top:2em; font-weight: bold;}
+.subparagraphHead, .likesubparagraphHead { font-weight: bold;}
+.verse{white-space:nowrap; margin-left:2em}
+div.maketitle {text-align:center;}
+h2.titleHead{text-align:center;}
+div.maketitle{ margin-bottom: 2em; }
+div.author, div.date {text-align:center;}
+div.thanks{text-align:left; margin-left:10%; font-size:85%; font-style:italic; }
+div.author{white-space: nowrap;}
+div.abstract p {margin-left:5%; margin-right:5%;}
+div.abstract {width:100%;}
+.abstracttitle{text-align:center;margin-bottom:1em;}
+figure.float, div.figure {margin-left: auto; margin-right: auto;}
+figure.figure {text-align:center;}
+figcaption.caption {text-indent:-2em; margin-left:3em; margin-right:1em; text-align:center;}
+figcaption.caption span.id{font-weight: bold; white-space: nowrap; }
+p + figcaption, img + figcaption{margin-top: 1em;}
+.abstract{margin:1em;}
+.rotatebox{display: inline-block;}
+code.lstinline{font-family:monospace,monospace;}
+pre.listings{font-family: monospace,monospace; white-space: pre-wrap; margin-top:0.5em; margin-bottom:0.5em; }
+.lstlisting .label{margin-right:0.5em; }
+pre.lstlisting{font-family: monospace,monospace; white-space: pre-wrap; margin-top:0.5em; margin-bottom:0.5em; }
+pre.lstinputlisting{ font-family: monospace,monospace; white-space: pre-wrap; }
+.lstinputlisting .label{margin-right:0.5em;}
+.equation td{text-align:center; }
+.equation-star td{text-align:center; }
+table.equation-star { width:100%; }
+table.equation { width:100%; }
+table.align, table.alignat, table.xalignat, table.xxalignat, table.flalign {width:95%; margin-left:5%; white-space: nowrap;}
+table.align-star, table.alignat-star, table.xalignat-star, table.flalign-star {margin-left:auto; margin-right:auto; white-space: nowrap;}
+td.align-label { width:5%; text-align:center; }
+td.align-odd { text-align:right; padding-right:0.3em;}
+td.align-even { text-align:left; padding-right:0.6em;}
+table.multline, table.multline-star {width:100%;}
+td.gather {text-align:center; }
+table.gather {width:100%;}
+div.gather-star {text-align:center;}
+ figure.figure { text-align: left; } 
+/* end css.sty */
+

--- a/src/.devcontainer/README.md
+++ b/src/.devcontainer/README.md
@@ -1,0 +1,61 @@
+# Speed HPC Utilities
+
+## Development Container for LaTeX
+
+> For use with [Visual Studio Code](https://code.visualstudio.com/) editor. [Details on this dev container extension](https://code.visualstudio.com/docs/devcontainers/containers).
+
+### Introduction
+
+This folder contains the necessary Docker files and environment dependencies like plugins and extensions to start up a containerized environment with full support for authoring and building LaTeX documents.
+
+The dev container configuration uses the container image from [qmcgaw/latexdevcontainer](https://hub.docker.com/r/qmcgaw/latexdevcontainer/) with `latest-full` tag.
+
+The `devcontainer.json` manifests the recommended Visual Studio Code extensions.
+
+### Requirements
+
+- Windows 10/11 x86-64 >= 1909 | x86-64 Linux distribution | macOS >=10.15 (Catalina)
+- Visual Studio Code
+- [Docker](https://docs.docker.com/get-docker/)
+- (After starting the container), you might need to run `apt install make build-essentail` to install the missing packages in the base container.
+
+### Usage
+
+- Open the repository root folder
+- CTRL + SHIFT + P to bring up the command palette
+- Search for "Dev Container: Reopen in Container" and hit enter to run.
+
+VS Code will then start a Docker container using the image and configurations mentioned above and automatically start a remote connection to the container using `ssh`.
+
+### Understanding the files
+
+> Note that the filenames are case-sensitive. On a non-sensitive OS like Windows, misnaming the file may result in undefined reference errors when using SCM tools (like git) across other OS's (Linux, macOS).
+
+#### `devcontainer.json`
+
+This file contains the properties (instructions) on how the dev container is set up for Code to remote into, as well as which useful extensions to install and settings to configure on container startup.
+
+An important for this repository is `dockerComposeFile` (see [docker-compose.yml](#docker-composeyml)).
+
+For more information on the properties, visit [containers.dev](https://containers.dev/implementors/json_reference/)
+
+#### `Dockerfile`
+
+This file is used by Docker as a set of instructions to build a container image. The build process starts from a base image. In our case, it is a prebuilt image with the necessary LaTeX tools loaded already.
+
+[Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
+ | [Base image reference](https://hub.docker.com/r/qmcgaw/latexdevcontainer)
+
+#### `docker-compose.yml`
+
+Normally a `docker-compose.yml` file is used for starting up multiple peer-dependent containers. For example, a full-stack application orchestration may have these containers: frontend (running Apache2 or Node application), database (PostgreSQL, mongoDB), cache (Redis), or API gateway (nginx).
+
+In our case, we use the file to give the directives for mounting the project folder, local Docker socket folder, local shell environment, etc. as a volume on the single dev container.
+
+The `entrypoint` attribute at the end of the file to work around a bug from VS Code >= 1.64 (currently v1.73) when spinning up the containers using the extension. The workaround was detailed in this issue on the VS Code's repository: [microsoft/vscode-remote-release#6337](https://github.com/microsoft/vscode-remote-release/issues/6337).
+
+[docker-compose.yml reference](https://docs.docker.com/compose/compose-file/)
+
+#### `.dockerignore`
+
+Functions similarly to the `.gitignore` in that it specifies the files and folders to exclude when running the `COPY` command in `Dockerfile`.

--- a/src/.devcontainer/docker-compose.yml
+++ b/src/.devcontainer/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.2"
+
+services:
+  vscode:
+    build: .
+    image: latexdevcontainer
+    volumes:
+      - ../../:/workspace
+      # Docker socket to access Docker server
+      - /var/run/docker.sock:/var/run/docker.sock
+      # SSH directory
+      - ~/.ssh:/root/.ssh
+      # For Windows without WSL, a copy will be made
+      # from /tmp/.ssh to ~/.ssh to fix permissions
+      # - ~/.ssh:/tmp/.ssh:ro
+      # Shell history persistence
+      - ~/.zsh_history:/root/.zsh_history:z
+      # Git config
+      - ~/.gitconfig:/root/.gitconfig
+    environment:
+      - TZ=
+    entrypoint: ["zsh", "-c", "while sleep 1000; do :; done"]


### PR DESCRIPTION
This PR addresses issue #19 
- Fixed one particular `file` command in `speed-manual.tex` that escapes during the HTML rendering.
- Created configurations for `make4ht`, the tool to generate HTML and CSS from `speed-manual.tex`.
    - Ignored artifacts created by the `make4ht` tool.
    - Generated HTML, CSS outputs in [doc/web](doc/web).
    - Added html build steps in [doc/Makefile](doc/Makefile).
- Added [doc/.devcontainer](doc/.devcontainer).
- Added [.github](.github) to trigger static page deployment to Github Pages.
