### PR TITLE
Improve devcontainer capabilities and DX

### DIFF
--- a/doc/.devcontainer/Dockerfile
+++ b/doc/.devcontainer/Dockerfile
@@ -1,1 +1,9 @@
 FROM qmcgaw/latexdevcontainer:latest-full
+
+# The following declarative commands are meant to extend the capabilities of the base Docker image
+
+# Set not to invoke the Debian UI when using `apt[-get]`
+RUN export DEBIAN_FRONTEND=noninteractive
+
+# Install the missing `make` tool
+RUN apt update -y && apt install -y make build-essential --no-install-recommends

--- a/doc/.devcontainer/README.md
+++ b/doc/.devcontainer/README.md
@@ -6,26 +6,25 @@
 
 ### Introduction
 
-This folder contains the necessary Docker files and environment dependencies like plugins and extensions to start up a containerized environment with full support for authoring and building LaTeX documents.
+This folder contains the necessary Docker files and environment dependencies, e.g. plugins and extensions, to start up a containerized environment with full support for authoring and building LaTeX documents.
 
 The dev container configuration uses the container image from [qmcgaw/latexdevcontainer](https://hub.docker.com/r/qmcgaw/latexdevcontainer/) with `latest-full` tag.
 
-The `devcontainer.json` manifests the recommended Visual Studio Code extensions.
+The `devcontainer.json` manifests the recommended Visual Studio Code extensions and workspace configurations.
 
 ### Requirements
 
 - Windows 10/11 x86-64 >= 1909 | x86-64 Linux distribution | macOS >=10.15 (Catalina)
 - Visual Studio Code
 - [Docker](https://docs.docker.com/get-docker/)
-- (After starting the container), you might need to run `apt install make build-essentail` to install the missing packages in the base container.
 
 ### Usage
 
-- Open the repository root folder
-- CTRL + SHIFT + P to bring up the command palette
+- Open the repository root folder.
+- <kbd>CTRL / ⌘ cmd + SHIFT + P</kbd> to bring up the command palette.
 - Search for "Dev Container: Reopen in Container" and hit enter to run.
 
-VS Code will then start a Docker container using the image and configurations mentioned above and automatically start a remote connection to the container using `ssh`.
+VS Code will then start a Docker container using the default image and configurations in this repository and automatically start a remote connection to the container using `ssh`.
 
 ### Understanding the files
 

--- a/doc/.devcontainer/docker-compose.yml
+++ b/doc/.devcontainer/docker-compose.yml
@@ -2,8 +2,10 @@ version: "3.2"
 
 services:
   vscode:
-    build: .
     image: latexdevcontainer
+    build: 
+      context: .
+      dockerfile: ./Dockerfile
     volumes:
       - ../../:/workspace
       # Docker socket to access Docker server
@@ -24,4 +26,3 @@ services:
     # that prevents initial handshake between the IDE 
     # to the newly created container
     entrypoint: ["zsh", "-c", "while sleep 1000; do :; done"]
- 


### PR DESCRIPTION
- devcontainer will now install `make` and `build-essential` by default when starting up for the first time via VS Code. 
     For existing containers, run the Devcontainer: Rebuild and Reopen... command from the command palette.

- Update README to reflect the changes