### PR TITLE
add VSCode instructions (web-based and local version)

### DIFF
--- a/doc/job-management/interactive-jobs.tex
+++ b/doc/job-management/interactive-jobs.tex
@@ -323,42 +323,39 @@ jupyter lab --no-browser --notebook-dir=$PWD --ip="0.0.0.0" --port=8888 --port-r
 \subsubsection{Visual Studio Code}
 \label{sect:vscode}
 
-This is an example of running VScode, it's similar to Jupyter notebooks, but
-it doesn't use containers. \textbf{Note:} this a Web-based version; there exists the local
-(workstation)~--~remote (speed-node) client-server version too, but it is for advanced users
-and is out of scope here (so no support, use it at your own risk).
+This is an example of running VS Code on Speed
 
-\begin{itemize}
-\item Environment preparation: for the FIRST time:
+\textbf{Note: } There are two ways to run Visual Studio Code (VS Code) on Speed.
+
+% 2.8.4.1 Web-based Version
+% ----------------------------------------------
+\paragraph{Web-based Version}
+\label{sect:web-based-vscode}
+\noindent Similar to Jupyter notebooks.
+
 \begin{enumerate}
-    \item Go to your speed-scratch directory: \texttt{cd /speed-scratch/\$USER}
-    \item Create a vscode directory: \texttt{mkdir vscode}
-    \item Create another directory: \texttt{mkdir -p /speed-scratch/\$USER/run-user}
+    \item Start an interactive session: \texttt{salloc --job-name=vs-code --mem=10G}
+    \item Run the script: \texttt{./vscode_web.sh}
+    \begin{itemize}
+        \item Create a vscode directory (with subdirectories run-user and workspace)
+        \item Set the environment variable \texttt{XDG\_RUNTIME\_DIR} appropriately. 
+        \item Print the SSH tunnel command required to forward port 8080 from the compute node to your local machine.
+        \item Launch code-server in the background, which generates a configuration file (including the VS Code password).
+    \end{itemize}
+    \item Connect from your local machine:
+    \begin{itemize}
+        \item Open your web browser and navigate to http://localhost:8080.
+        \item If prompted for a password, use the password printed by the script.
+    \end{itemize}
 \end{enumerate}
 
-\item Running VScode
-\begin{enumerate}
-    \item Go to your vscode directory:
-    \texttt{cd /speed-scratch/\$USER/vscode}
-    \item Open interactive session:
-    \texttt{salloc --mem=10Gb --constraint=el9}
-    \item Set environment variable:
-    \texttt{setenv XDG\_RUNTIME\_DIR /speed-scratch/\$USER/run-user}
-    \item Run VScode, change the port if needed.
-    \scriptsize
-    \begin{verbatim}
-/speed-scratch/nag-public/code-server-4.22.1/bin/code-server --user-data-dir=$PWD\/projects \
---config=$PWD\/home/.config/code-server/config.yaml --bind-addr="0.0.0.0:8080" $PWD\/projects
-    \end{verbatim}
-    \normalsize
-    \item SSH Tunnel creation: similar to Jupyter, see \xs{sect:jupyter-singularity}
-    \item Open a browser and type: \texttt{localhost:8080}
-    \item If the browser asks for a password, consult:
-    \begin{verbatim}
-    cat /speed-scratch/$USER/vscode/home/.config/code-server/config.yaml
-    \end{verbatim}
-\end{enumerate}
-\end{itemize}
+\small
+\begin{figure}[htpb]
+    \lstinputlisting[language=csh,frame=single,basicstyle=\ttfamily\scriptsize]{../../src/vscode/vscode_web.sh}
+    \caption{Source code for \file{vscode_web.sh}}
+    \label{fig:vscode_web.sh}
+\end{figure}
+\normalsize
 
 \begin{figure}[htbp]
 	\centering
@@ -366,3 +363,9 @@ and is out of scope here (so no support, use it at your own risk).
 	\caption{VScode running on a Speed node}
 	\label{fig:vscode}
 \end{figure}
+
+% 2.8.4.2 Local Version
+% ----------------------------------------------
+\paragraph{Local Version}
+\label{sect:local-vscode}
+\noindent If you prefer running VS Code without needing a separate browser-based code-server. Instructions can be found in \tool{/src/vscode} \href{https://github.com/NAG-DevOps/speed-hpc/blob/master/src/vscode}{README.md} file.

--- a/src/vscode/README.md
+++ b/src/vscode/README.md
@@ -5,19 +5,107 @@ a **step-by-step** guide to running VS Code directly on the Speed HPC cluster.
 
 <!-- TOC --><a name="Prerequisites"></a>
 ## Prerequisites
-Before starting, ensure you have [access](https://nag-devops.github.io/speed-hpc/#requesting-access) to Speed.
 
-2. SSH to Speed (Requires VPN if off-campus).
-    -> VPN Setup: [How to connect to the Virtual Private Network](https://www.concordia.ca/it/support/connect-from-home.html)
+1. **Access to Speed**
+   Before starting, ensure you have [access to Speed](https://nag-devops.github.io/speed-hpc/#requesting-access).
 
-        ssh <ENCSusername>@speed.encs.concordia.ca
+2. **SSH to Speed (Requires VPN if off-campus)**
+   - VPN Setup: [How to connect to the Virtual Private Network](https://www.concordia.ca/it/support/connect-from-home.html)
+     ```bash
+     ssh <ENCSusername>@speed.encs.concordia.ca
+     ```
+    Replace `<ENCSusername>` with your ENCS username.
 
-    replace `<ENCSusername>` with your ENCS username
-* Clone the Github repository
+3. **Clone the GitHub Repository**
+     ```bash
+     git clone --depth=1 https://github.com/NAG-DevOps/speed-hpc.git
+     ```
 
-        git clone --depth=1 https://github.com/NAG-DevOps/speed-hpc.git
+4. Navigate to the vscode directory in `src`
 
-* Navigate to the vscode directory in `src`
+<!-- TOC --><a name="Instructions"></a>
+## Instructions
+There are two ways to run Visual Studio Code (VS Code) on Speed.
 
-There's two ways to run Visual Studio Code (VS Code).
+### Web-based Version
+1. Start an interactive session
+     ```bash
+     salloc --job-name=vs-code --mem=10G
+     ```
 
+2. Run the script `vscode_web.sh`
+     ```bash
+     ./vscode_web.sh
+     ```
+     The script will:
+   - Create a \'vscode\' directory (with subdirectories \'run-user\' and \'workspace\')
+   - set the environment variable `XDG_RUNTIME_DIR` appropriately.
+   - Print the SSH tunnel command required to forward port 8080 from the compute node to your local machine.
+   - Launch code-server in the background, which generates a configuration file (including the VS Code password).
+
+3. Connect from your local machine:
+   - Open your web browser and navigate to http://localhost:8080.
+   - If prompted for a password, use the password printed by the script.
+
+> ❗ **IMPORTANT**: Keep this session open to maintain the VS Code server running. When you're done, type 'exit' to terminate the session.
+
+### Running VS Code Locally
+If you prefer running VS Code without needing a separate browser-based code-server.
+
+1. Install "Remote - SSH" extension:
+   - In VS Code, open the **Extensions** icon (left sidebar).
+   - Search **Remote - SSH** (by Microsoft).
+   - Click Install.
+
+2. Start an interactive session:
+     ```bash
+     salloc --job-name=vs-code --mem=10G
+     ```
+    Note the compute node name (for example, speed-40.encs.concordia.ca). Keep the session open.
+
+3. Edit your local SSH config file:
+    - **On Windows**: Typically located at `C:\Users\<YourName>\.ssh\config`
+    - **On macOS/Linux**: Located at `~/.ssh/config`
+   
+    You will need to define two “hosts” in your local SSH config:
+    - **speed** (the login/submit node, `speed.encs.concordia.ca`)
+    - **speed-compute** (the compute node you got, e.g., `speed-40.encs.concordia.ca`), which uses `ProxyJump speed` that tells SSH to hop from your
+          local machine → the login node → the compute node.
+   
+     ```text
+      # Speed-submit (login) node
+      Host speed
+      HostName speed.encs.concordia.ca
+      User <ENCSusername>
+
+      # Speed compute node
+      Host speed-compute
+      HostName <compute-node>.encs.concordia.ca
+      User <ENCSusername>
+      ProxyJump speed
+      ForwardAgent yes
+     ```
+     
+    Replace `<ENCSusername>` with your ENCS username and `<compute-node>` with the actual compute node name (e.g., speed-40).
+        - `ProxyJump speed` 
+
+4. Connect via VS Code Remote - SSH:
+    - In VS Code, open the Command Palette `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS)
+    - Select **Remote-SSH: Connect to Host...** and choose `speed-compute`
+    - Follow the prompts to connect (you may be asked for your SSH password or a confirmation).
+    - Once connected, a new VS Code window will open. Verify the status bar shows “SSH: speed-compute”.
+
+5. Open and edit files on Speed:
+    - In the new VS Code window, go to File → Open Folder… and navigate to a directory such as `/speed-scratch/<ENCSusername>/my_project`
+    - Open a remote terminal via Terminal → New Terminal. This terminal will run on the compute node.
+    - Edit files as needed. All changes occur on the HPC node.
+
+> NOTE:\
+> When your interactive job ends, your compute node is freed, and your VS Code session drops.\
+> Each time you get a new compute node, update the `HostName` in your SSH config.
+ 
+## References
+- Speed manual:
+    - Speed Manual PDF: https://github.com/NAG-DevOps/speed-hpc/blob/master/doc/speed-manual.pdf
+    - Speed Manual HTML: https://nag-devops.github.io/speed-hpc/ 
+- GitHub Repository (PRs are welcome): https://github.com/NAG-DevOps/speed-hpc

--- a/src/vscode/README.md
+++ b/src/vscode/README.md
@@ -1,0 +1,23 @@
+<!-- TOC --><a name="README"></a>
+# VS Code on Speed
+
+a **step-by-step** guide to running VS Code directly on the Speed HPC cluster. 
+
+<!-- TOC --><a name="Prerequisites"></a>
+## Prerequisites
+Before starting, ensure you have [access](https://nag-devops.github.io/speed-hpc/#requesting-access) to Speed.
+
+2. SSH to Speed (Requires VPN if off-campus).
+    -> VPN Setup: [How to connect to the Virtual Private Network](https://www.concordia.ca/it/support/connect-from-home.html)
+
+        ssh <ENCSusername>@speed.encs.concordia.ca
+
+    replace `<ENCSusername>` with your ENCS username
+* Clone the Github repository
+
+        git clone --depth=1 https://github.com/NAG-DevOps/speed-hpc.git
+
+* Navigate to the vscode directory in `src`
+
+There's two ways to run Visual Studio Code (VS Code).
+

--- a/src/vscode/ssh-config
+++ b/src/vscode/ssh-config
@@ -1,0 +1,11 @@
+# Speed-submit (login) node
+Host speed
+HostName speed.encs.concordia.ca
+User <ENCSusername>
+
+# Speed compute node
+Host speed-compute
+HostName <compute-node>.encs.concordia.ca
+User <ENCSusername>
+ProxyJump speed
+ForwardAgent yes

--- a/src/vscode/vscode_web.sh
+++ b/src/vscode/vscode_web.sh
@@ -1,0 +1,45 @@
+#!/encs/bin/tcsh
+
+date
+echo "======================================================================\n"
+# Go to your scratch directory.
+cd /speed-scratch/$USER
+mkdir -p vscode/run-user
+cd vscode
+mkdir -p workspace
+
+setenv XDG_RUNTIME_DIR /speed-scratch/$USER/vscode/run-user
+
+# Get the current node and user information
+set node = `hostname -s`
+set user = `whoami`
+
+echo "To connect to this node from your local machine, open a new terminal and run:"
+echo ""
+echo " ssh -L 8080:${node}:8080 ${user}@speed.encs.concordia.ca"
+echo ""
+echo "Then, open your browser and go to: http://localhost:8080"
+echo ""
+echo "======================================================================\n"
+echo "Launching vs code-server:"
+
+nohup /speed-scratch/nag-public/code-server-4.22.1/bin/code-server \
+    --user-data-dir=${PWD}/workspace \
+    --config=${PWD}/home/.config/code-server/config.yaml \
+    --bind-addr="0.0.0.0:8080" ${PWD}/workspace &
+
+    # Wait for the config file (which contains the password) to be created.
+    set CONFIG_FILE = "${PWD}/home/.config/code-server/config.yaml"
+    while ( ! -e $CONFIG_FILE )
+        echo "Waiting for the config file to be created..."
+        sleep 2
+    end
+
+    echo ""
+    echo "======================================================================\n"
+    cat $CONFIG_FILE
+    echo ""
+    echo "======================================================================\n"
+    echo "IMPORTANT: Keep this session open to maintain the VS Code server running."
+    echo "When you're done, type 'exit' to terminate the session."
+    echo ""


### PR DESCRIPTION
I have created the script for running VS Code server for the web-based version, and the README file explains how to run both versions (web-based and locally).